### PR TITLE
fix: clean up dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,22 @@
-FROM apeworx/ape:latest
+#---------------------------------------------------------------------------------------------
+# See LICENSE in the project root for license information.
+#---------------------------------------------------------------------------------------------
 
+# Build with builder image to reduce image size
+FROM apeworx/ape:latest as builder
 USER root
-RUN pip install silverback
+WORKDIR /wheels
+COPY . .
+RUN pip install --upgrade pip \
+    && pip install wheel \
+    && pip wheel silverback --wheel-dir=/wheels
+
+# Install from wheels
+FROM apeworx/ape:latest
+USER root
+COPY --from=builder /wheels /wheels
+RUN pip install --upgrade pip \
+    pip install . --no-cache-dir --find-links=/wheels
 USER harambe
 
 ENTRYPOINT ["silverback"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 # upgrade pip and install wheel
 RUN pip install --upgrade pip && pip install wheel
 # install silverback
-RUN pip wheel silverback --wheel-dir=/wheels
+RUN pip wheel . --wheel-dir=/wheels
 
 # Install from wheels
 FROM apeworx/ape:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,21 @@
 #---------------------------------------------------------------------------------------------
 
 # Build with builder image to reduce image size
-FROM apeworx/ape:latest as builder
+FROM python:3.10 as builder
 USER root
 WORKDIR /wheels
 COPY . .
-RUN pip install --upgrade pip \
-    && pip install wheel \
-    && pip wheel silverback --wheel-dir=/wheels
+# upgrade pip and install wheel
+RUN pip install --upgrade pip && pip install wheel
+# install silverback
+RUN pip wheel silverback --wheel-dir=/wheels
 
 # Install from wheels
 FROM apeworx/ape:latest
 USER root
 COPY --from=builder /wheels /wheels
 RUN pip install --upgrade pip \
-    pip install . --no-cache-dir --find-links=/wheels
+    && pip install silverback --no-cache-dir --find-links=/wheels 
 USER harambe
 
 ENTRYPOINT ["silverback"]


### PR DESCRIPTION
### What I did

Clean up the dockerfile, and build from builder with wheels

fixes: issue where the silverback docker image does not have the newest version of silverback

### How I did it

cleaned up the dockerfile using the techniques used in ape core

### How to verify it

build the dockerfile

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
