### PR TITLE
feat: include exception type in log message

### DIFF
--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -83,4 +83,4 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
         result: TaskiqResult,
         exception: BaseException,
     ):
-        logger.error(f"{message.task_name} - Exception: {exception}")
+        logger.error(f"{message.task_name} - {type(exception).__name__}: {exception}")

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -61,7 +61,7 @@ class BaseRunner(ABC):
         try:
             await asyncio.gather(*tasks)
         except Exception as e:
-            logger.error(f"Critical exception: {e}")
+            logger.error(f"Critical exception, {type(e).__name__}: {e}")
 
         finally:
             await self.app.broker.shutdown()


### PR DESCRIPTION
### What I did

Right now the exception just always says `Exception` and if there is not much of a message, such as unknown ecosystem, then it is really confusing. Also confused why `ethereum` is an unknown ecosystem but that is another story


It used to say:

```
ERROR: 0xb5ED1eF2a90527b402Cd7e7d415027CB94E1Db4E/event/StreamCreated - Exception: ethereum
```

Now it looks like:

```
ERROR: 0xb5ED1eF2a90527b402Cd7e7d415027CB94E1Db4E/event/StreamCreated - UnknownEcosystem: ethereum
```

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
