### PR TITLE
feat: start block setting

### DIFF
--- a/example.py
+++ b/example.py
@@ -27,7 +27,7 @@ def exec_block(block: BlockAPI):
 
 # This is how we trigger off of events
 # Set new_block_timeout to adjust the expected block time.
-@app.on_(USDC.Transfer, new_block_timeout=25)
+@app.on_(USDC.Transfer, start_block=17793100, new_block_timeout=25)
 # NOTE: Typing isn't required
 def exec_event1(log):
     if log.log_index % 7 == 3:

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -35,6 +35,7 @@ class SilverBackApp(ManagerAccessMixin):
 
         self.signer = settings.get_signer()
         self.new_block_timeout = settings.NEW_BLOCK_TIMEOUT
+        self.start_block = settings.START_BLOCK
 
         network_str = f'\n  NETWORK="{provider.network.ecosystem.name}:{provider.network.name}"'
         signer_str = f"\n  SIGNER={repr(self.signer)}"
@@ -64,6 +65,7 @@ class SilverBackApp(ManagerAccessMixin):
         self,
         container: Union[BlockContainer, ContractEvent],
         new_block_timeout: Optional[int] = None,
+        start_block: Optional[int] = None,
     ):
         if isinstance(container, BlockContainer):
             if self.get_block_handler():
@@ -74,6 +76,12 @@ class SilverBackApp(ManagerAccessMixin):
                     self.poll_settings["_blocks_"]["new_block_timeout"] = new_block_timeout
                 else:
                     self.poll_settings["_blocks_"] = {"new_block_timeout": new_block_timeout}
+
+            if start_block is not None:
+                if "_blocks_" in self.poll_settings:
+                    self.poll_settings["_blocks_"]["start_block"] = start_block
+                else:
+                    self.poll_settings["_blocks_"] = {"start_block": start_block}
 
             return self.broker.task(task_name="block")
 
@@ -94,6 +102,12 @@ class SilverBackApp(ManagerAccessMixin):
                     self.poll_settings[key]["new_block_timeout"] = new_block_timeout
                 else:
                     self.poll_settings[key] = {"new_block_timeout": new_block_timeout}
+
+            if start_block is not None:
+                if key in self.poll_settings:
+                    self.poll_settings[key]["start_block"] = start_block
+                else:
+                    self.poll_settings[key] = {"start_block": start_block}
 
             return self.broker.task(
                 task_name=f"{container.contract.address}/event/{container.abi.name}"

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -78,17 +78,18 @@ class LiveRunner(BaseRunner):
 
     async def _block_task(self, block_handler: AsyncTaskiqDecoratedTask):
         new_block_timeout = None
-        if (
-            "_blocks_" in self.app.poll_settings
-            and "new_block_timeout" in self.app.poll_settings["_blocks_"]
-        ):
-            new_block_timeout = self.app.poll_settings["_blocks_"]["new_block_timeout"]
+        start_block = None
+        if "_blocks_" in self.app.poll_settings:
+            block_settings = self.app.poll_settings["_blocks_"]
+            new_block_timeout = block_settings.get("new_block_timeout")
+            start_block = block_settings.get("start_block")
 
         new_block_timeout = (
             new_block_timeout if new_block_timeout is not None else self.app.new_block_timeout
         )
+        start_block = start_block if start_block is not None else self.app.start_block
         async for block in async_wrap_iter(
-            chain.blocks.poll_blocks(new_block_timeout=new_block_timeout)
+            chain.blocks.poll_blocks(start_block=start_block, new_block_timeout=new_block_timeout)
         ):
             block_task = await block_handler.kiq(block)
             result = await block_task.wait_result()
@@ -98,19 +99,20 @@ class LiveRunner(BaseRunner):
         self, contract_event: ContractEvent, event_handler: AsyncTaskiqDecoratedTask
     ):
         new_block_timeout = None
+        start_block = None
         if isinstance(contract_event.contract, ContractInstance):
             address = contract_event.contract.address
-            if (
-                address in self.app.poll_settings
-                and "new_block_timeout" in self.app.poll_settings[address]
-            ):
-                new_block_timeout = self.app.poll_settings[address]["new_block_timeout"]
+            if address in self.app.poll_settings:
+                address_settings = self.app.poll_settings[address]
+                new_block_timeout = address_settings.get("new_block_timeout")
+                start_block = address_settings.get("start_block")
 
         new_block_timeout = (
             new_block_timeout if new_block_timeout is not None else self.app.new_block_timeout
         )
+        start_block = start_block if start_block is not None else self.app.start_block
         async for event in async_wrap_iter(
-            contract_event.poll_logs(new_block_timeout=new_block_timeout)
+            contract_event.poll_logs(start_block=start_block, new_block_timeout=new_block_timeout)
         ):
             event_task = await event_handler.kiq(event)
             result = await event_task.wait_result()

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings, ManagerAccessMixin):
     SIGNER_ALIAS: str = ""
 
     NEW_BLOCK_TIMEOUT: Optional[int] = None
+    START_BLOCK: Optional[int] = None
 
     class Config:
         env_prefix = "SILVERBACK_"


### PR DESCRIPTION
### What I did

Allow setting `start_block` everywhere, same as we did for new block timeout.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
