### PR TITLE
fix: make sure that envvars can override the default network option [SBK-223]

### DIFF
--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -2,7 +2,7 @@ import asyncio
 import os
 
 import click
-from ape.cli import AccountAliasPromptChoice, NetworkBoundCommand, network_option, verbosity_option
+from ape.cli import AccountAliasPromptChoice, ape_cli_context, network_option, verbosity_option
 
 from silverback._importer import import_from_string
 from silverback.runner import LiveRunner
@@ -13,18 +13,23 @@ def cli():
     """Work with SilverBack applications in local context (using Ape)."""
 
 
-@cli.command(cls=NetworkBoundCommand)
+@cli.command()
+@ape_cli_context()
 @verbosity_option()
-@network_option()
+@network_option(default=None)
 @click.option("--account", type=AccountAliasPromptChoice(), default=None)
 @click.option("-x", "--max-exceptions", type=int, default=3)
 @click.argument("path")
-def run(network, account, max_exceptions, path):
-    os.environ["SILVERBACK_NETWORK_CHOICE"] = network
+def run(cli_ctx, network, account, max_exceptions, path):
+    if network:
+        os.environ["SILVERBACK_NETWORK_CHOICE"] = network
+    else:
+        network = os.environ.get("SILVERBACK_NETWORK_CHOICE", "")
 
     if account:
         os.environ["SILVERBACK_SIGNER_ALIAS"] = account.alias.replace("dev_", "TEST::")
 
-    app = import_from_string(path)
-    runner = LiveRunner(app, max_exceptions=max_exceptions)
-    asyncio.run(runner.run())
+    with cli_ctx.network_manager.parse_network_choice(network):
+        app = import_from_string(path)
+        runner = LiveRunner(app, max_exceptions=max_exceptions)
+        asyncio.run(runner.run())


### PR DESCRIPTION
### What I did

Fixes issue where the `SILVERBACK_NETWORK_CHOICE` envvar did not take precedence

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
