### PR TITLE
feat!: websocket runner [SBK-244]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     url="https://github.com/SilverBackLtd/sdk",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.15,<1.0",
+        "eth-ape>=0.6.19,<1.0",
         "taskiq[metrics]>=0.6.0,<0.7.0",
         "click",  # Use same version as eth-ape
     ],

--- a/silverback/__init__.py
+++ b/silverback/__init__.py
@@ -1,10 +1,8 @@
 from .application import SilverBackApp
 from .exceptions import CircuitBreaker, SilverBackException
-from .runner import LiveRunner
 
 __all__ = [
     "CircuitBreaker",
-    "LiveRunner",
     "SilverBackApp",
     "SilverBackException",
 ]

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -5,7 +5,7 @@ import click
 from ape.cli import AccountAliasPromptChoice, ape_cli_context, network_option, verbosity_option
 
 from silverback._importer import import_from_string
-from silverback.runner import LiveRunner
+from silverback.runner import PollingRunner
 
 
 @click.group()
@@ -15,7 +15,7 @@ def cli():
 
 def _runner_callback(ctx, param, val):
     if not val:
-        return LiveRunner
+        return PollingRunner
 
     elif runner := import_from_string(val):
         return runner

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -18,6 +18,13 @@ class InvalidContainerType(Exception):
         super().__init__(f"Invalid container type: {container.__class__}")
 
 
+class NoWebsocketAvailable(Exception):
+    def __init__(self):
+        super().__init__(
+            "Attempted to a use WebsocketRunner without a websocket-compatible provider."
+        )
+
+
 class SilverBackException(ApeException):
     pass
 

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -63,7 +63,7 @@ class BaseRunner(ABC):
         await self.app.broker.shutdown()
 
 
-class LiveRunner(BaseRunner):
+class PollingRunner(BaseRunner):
     """
     Run a single app against a live network using a basic in-memory queue.
     """

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -2,12 +2,16 @@ import asyncio
 from abc import ABC, abstractmethod
 
 from ape import chain
+from ape.api import UpstreamProvider
 from ape.contracts import ContractEvent, ContractInstance
 from ape.logging import logger
+from ape.utils import ManagerAccessMixin
+from ape_ethereum.ecosystem import keccak
 from taskiq import AsyncTaskiqDecoratedTask, TaskiqResult
 
 from .application import SilverBackApp
 from .exceptions import Halt, SilverBackException
+from .subscriptions import SubscriptionType, Web3SubscriptionsManager
 from .utils import async_wrap_iter
 
 
@@ -63,6 +67,67 @@ class BaseRunner(ABC):
         await self.app.broker.shutdown()
 
 
+class WebsocketRunner(BaseRunner, ManagerAccessMixin):
+    """
+    Run a single app against a live network using a basic in-memory queue and websockets.
+    """
+
+    def __init__(self, app: SilverBackApp, *args, **kwargs):
+        super().__init__(app, *args, **kwargs)
+        logger.info(f"Using {self.__class__.__name__}: max_exceptions={self.max_exceptions}")
+
+        # Check for websocket support
+        provider = app.chain_manager.provider
+        if isinstance(provider, UpstreamProvider):
+            uri = provider.connection_str
+        elif hasattr(provider, "uri"):
+            # Most Web3Providers
+            uri = provider.uri
+        else:
+            raise
+
+        self.ws_uri = uri.replace("http", "ws")
+
+    async def _block_task(self, block_handler: AsyncTaskiqDecoratedTask):
+        sub_id = await self.subscriptions.subscribe(SubscriptionType.BLOCKS)
+        logger.debug(f"Handling blocks via {sub_id}")
+
+        async for raw_block in self.subscriptions.get_subscription_data(sub_id):
+            block_task = await block_handler.kiq(raw_block)
+            result = await block_task.wait_result()
+            self._handle_result(result)
+
+    async def _event_task(
+        self, contract_event: ContractEvent, event_handler: AsyncTaskiqDecoratedTask
+    ):
+        if not isinstance(contract_event.contract, ContractInstance):
+            # For type-checking.
+            raise ValueError("Contract instance required.")
+
+        sub_id = await self.subscriptions.subscribe(
+            SubscriptionType.EVENTS,
+            address=contract_event.contract.address,
+            topics=["0x" + keccak(text=contract_event.abi.selector).hex()],
+        )
+        logger.debug(f"Handling '{contract_event.name}' events via {sub_id}")
+
+        async for raw_event in self.subscriptions.get_subscription_data(sub_id):
+            event = next(  # NOTE: `next` is okay since it only has one item
+                self.provider.network.ecosystem.decode_logs(
+                    [raw_event],
+                    contract_event.abi,
+                )
+            )
+            event_task = await event_handler.kiq(event)
+            result = await event_task.wait_result()
+            self._handle_result(result)
+
+    async def run(self):
+        async with Web3SubscriptionsManager(self.ws_uri) as subscriptions:
+            self.subscriptions = subscriptions
+            await super().run()
+
+
 class PollingRunner(BaseRunner):
     """
     Run a single app against a live network using a basic in-memory queue.
@@ -70,7 +135,10 @@ class PollingRunner(BaseRunner):
 
     def __init__(self, app: SilverBackApp, *args, **kwargs):
         super().__init__(app, *args, **kwargs)
-        logger.info(f"Using {self.__class__.__name__}: max_exceptions={self.max_exceptions}")
+        logger.warning(
+            "The polling runner makes a significant amount of requests. "
+            "Do not use in production over long time periods unless you know what you're doing."
+        )
 
     async def _block_task(self, block_handler: AsyncTaskiqDecoratedTask):
         new_block_timeout = None

--- a/silverback/subscriptions.py
+++ b/silverback/subscriptions.py
@@ -1,0 +1,144 @@
+import asyncio
+import json
+from enum import Enum
+from typing import AsyncGenerator, Dict, List, Optional
+
+from ape.logging import logger
+from websockets import client as ws_client
+
+
+class SubscriptionType(Enum):
+    BLOCKS = "newHeads"
+    EVENTS = "logs"
+
+
+class Web3SubscriptionsManager:
+    websocket_reconnect_max_tries: int = 3
+    rpc_response_timeout_count: int = 10
+    subscription_polling_time: float = 0.1  # secs
+
+    def __init__(self, ws_provider_uri: str):
+        self._ws_provider_uri = ws_provider_uri
+
+        # Stateful
+        self._connection: Optional[ws_client.WebSocketClientProtocol] = None
+        self._last_request: int = 0
+        self._subscriptions: Dict[str, asyncio.Queue] = {}
+        self._rpc_msg_buffer: List[dict] = []
+        self._ws_lock = asyncio.Lock()
+
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__} uri={self._ws_provider_uri}>"
+
+    async def __aenter__(self) -> "Web3SubscriptionsManager":
+        self.connection = await ws_client.connect(self._ws_provider_uri)
+        return self
+
+    def __aiter__(self) -> "Web3SubscriptionsManager":
+        return self
+
+    async def __anext__(self) -> str:
+        if not self.connection:
+            raise StopAsyncIteration
+
+        message = await self.connection.recv()
+        # TODO: Handle retries when connection breaks
+
+        response = json.loads(message)
+        if response.get("method") == "eth_subscription":
+            sub_params: dict = response.get("params", {})
+            if not (sub_id := sub_params.get("subscription")) or not isinstance(sub_id, str):
+                logger.debug(f"Corrupted subscription data: {response}")
+                return response
+
+            if sub_id not in self._subscriptions:
+                self._subscriptions[sub_id] = asyncio.Queue()
+
+            await self._subscriptions[sub_id].put(sub_params.get("result", {}))
+
+        else:
+            self._rpc_msg_buffer.append(response)
+
+        return response
+
+    def _create_request(self, method: str, params: list) -> dict:
+        self._last_request += 1
+        return {
+            "jsonrpc": "2.0",
+            "id": self._last_request,
+            "method": method,
+            "params": params,
+        }
+
+    async def _get_response(self, request_id: int) -> dict:
+        if buffer := self._rpc_msg_buffer:
+            for idx, data in enumerate(buffer):
+                if data.get("id") == request_id:
+                    self._rpc_msg_buffer.pop(idx)
+                    return data
+
+        async with self._ws_lock:
+            tries = 0
+            while tries < self.rpc_response_timeout_count:
+                if self._rpc_msg_buffer and self._rpc_msg_buffer[-1].get("id") == request_id:
+                    return self._rpc_msg_buffer.pop()
+
+                await anext(self)  # Keep pulling until we get a response
+
+        raise RuntimeError("Timeout waiting for response.")
+
+    async def subscribe(self, type: SubscriptionType, **filter_params) -> str:
+        if not self.connection:
+            raise ValueError("Connection required.")
+
+        if type is SubscriptionType.BLOCKS and filter_params:
+            raise ValueError("blocks subscription doesn't accept filter params.")
+
+        request = self._create_request(
+            "eth_subscribe",
+            [type.value, filter_params] if type is SubscriptionType.EVENTS else [type.value],
+        )
+        await self.connection.send(json.dumps(request))
+        response = await self._get_response(request.get("id") or self._last_request)
+
+        sub_id = response.get("result")
+        if not sub_id:
+            # NOTE: Re-dumping message to avoid type-checking concerns.
+            raise ValueError(f"Missing subscription ID in response: {json.dumps(response)}.")
+
+        return sub_id
+
+    async def get_subscription_data(self, sub_id: str) -> AsyncGenerator[dict, None]:
+        while True:
+            if not (queue := self._subscriptions.get(sub_id)) or queue.empty():
+                async with self._ws_lock:
+                    # NOTE: Keep pulling until a message comes to process
+                    await anext(self)
+            else:
+                yield await queue.get()
+
+    async def unsubscribe(self, sub_id: str) -> bool:
+        if sub_id not in self._subscriptions:
+            raise ValueError(f"Unknown sub_id '{sub_id}'")
+
+        if not self.connection:
+            # Nothing to unsubscribe.
+            return True
+
+        request = self._create_request("eth_unsubscribe", [sub_id])
+        await self.connection.send(json.dumps(request))
+
+        response = await self._get_response(request.get("id") or self._last_request)
+        if success := response.get("result", False):
+            del self._subscriptions[sub_id]  # NOTE: Save memory
+
+        return success
+
+    async def __aexit__(self, exc_type, exc, tb):
+        try:
+            # Try to gracefully unsubscribe to all events
+            await asyncio.gather(*(self.unsubscribe(sub_id) for sub_id in self._subscriptions))
+
+        finally:
+            # Disconnect and release websocket
+            await self.connection.close()

--- a/silverback/subscriptions.py
+++ b/silverback/subscriptions.py
@@ -19,7 +19,7 @@ class Web3SubscriptionsManager:
 
     def __init__(self, ws_provider_uri: str):
         # TODO: Temporary until a more permanent solution is added to ProviderAPI
-        if "infura" in ws_provider_uri:
+        if "infura" in ws_provider_uri and "ws/v3" not in ws_provider_uri:
             ws_provider_uri = ws_provider_uri.replace("v3", "ws/v3")
 
         self._ws_provider_uri = ws_provider_uri

--- a/silverback/subscriptions.py
+++ b/silverback/subscriptions.py
@@ -83,7 +83,8 @@ class Web3SubscriptionsManager:
                 if self._rpc_msg_buffer and self._rpc_msg_buffer[-1].get("id") == request_id:
                     return self._rpc_msg_buffer.pop()
 
-                await anext(self)  # Keep pulling until we get a response
+                # NOTE: Python <3.10 does not support `anext` function
+                await self.__anext__()  # Keep pulling until we get a response
 
         raise RuntimeError("Timeout waiting for response.")
 
@@ -112,8 +113,9 @@ class Web3SubscriptionsManager:
         while True:
             if not (queue := self._subscriptions.get(sub_id)) or queue.empty():
                 async with self._ws_lock:
-                    # NOTE: Keep pulling until a message comes to process
-                    await anext(self)
+                    # Keep pulling until a message comes to process
+                    # NOTE: Python <3.10 does not support `anext` function
+                    await self.__anext__()
             else:
                 yield await queue.get()
 

--- a/silverback/subscriptions.py
+++ b/silverback/subscriptions.py
@@ -18,6 +18,10 @@ class Web3SubscriptionsManager:
     subscription_polling_time: float = 0.1  # secs
 
     def __init__(self, ws_provider_uri: str):
+        # TODO: Temporary until a more permanent solution is added to ProviderAPI
+        if "infura" in ws_provider_uri:
+            ws_provider_uri = ws_provider_uri.replace("v3", "ws/v3")
+
         self._ws_provider_uri = ws_provider_uri
 
         # Stateful


### PR DESCRIPTION
### What I did

Add support for using a websocket-based subscriptions for the polling algorithm

NOTE: Breaking change is renaming `LiveRunner` to to `PollingRunner` and removing it from export. `silverback run` will continue using the polling runner out of the box, however

### How I did it

Added `Web3SubscriptionManager` which allows multiple subscriptions to a Web3 RPC that supports `eth_subscribe`

NOTE: To use it, run your `silverback run` command with the `--runner silverback.runner:WebsocketRunner` flag

### How to verify it

I tried it with the example, seems to run okay. Needs more validation probably.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
