### PR TITLE
fix(docs): fix link to development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Some examples of these types of applications:
 
 ## Documentation
 
-Read the [development userguide](https://docs.apeworx.io/silverback/stable/development) to learn more how to develop an application.
+Read the [development userguide](https://docs.apeworx.io/silverback/stable/userguides/development.html) to learn more how to develop an application.
 
 ## Dependencies
 

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -65,12 +65,12 @@ class SilverbackApp(ManagerAccessMixin):
         network_str = f'\n  NETWORK="{provider.network.ecosystem.name}:{provider.network.name}"'
         signer_str = f"\n  SIGNER={repr(self.signer)}"
         start_block_str = f"\n  START_BLOCK={self.start_block}" if self.start_block else ""
-        new_bock_timeout_str = (
+        new_block_timeout_str = (
             f"\n  NEW_BLOCK_TIMEOUT={self.new_block_timeout}" if self.new_block_timeout else ""
         )
         logger.info(
             f"Loaded Silverback App:{network_str}"
-            f"{signer_str}{start_block_str}{new_bock_timeout_str}"
+            f"{signer_str}{start_block_str}{new_block_timeout_str}"
         )
 
     def on_startup(self) -> Callable:
@@ -132,7 +132,7 @@ class SilverbackApp(ManagerAccessMixin):
 
         Args:
             container: (Union[BlockContainer, ContractEvent]): The event source to watch.
-            new_block_timeout: (Optional[int]): Override for block timeoui that is acceptable.
+            new_block_timeout: (Optional[int]): Override for block timeout that is acceptable.
                 Defaults to whatever the app's settings are for default polling timeout are.
             start_block (Optional[int]): block number to start processing events from.
                 Defaults to whatever the latest block is.


### PR DESCRIPTION
### What I did

Fixes a link in the README, docstrings, and trivial var name misspellings. 

### How I did it

With my text editor.

### How to verify it

Look at it and click on it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
