### PR TITLE
fix: include args for __exit__ func sig [SBK-371]

### DIFF
--- a/silverback/application.py
+++ b/silverback/application.py
@@ -56,7 +56,7 @@ class SilverbackApp(ManagerAccessMixin):
         # NOTE: This allows using connected ape methods e.g. `Contract`
         provider = self.network.__enter__()
 
-        atexit.register(self.network.__exit__)
+        atexit.register(self.network.__exit__, None, None, None)
 
         self.signer = settings.get_signer()
         self.new_block_timeout = settings.NEW_BLOCK_TIMEOUT


### PR DESCRIPTION
### What I did

The func sig changed in `ProviderContextManager.__exit__()` requiring the expected arguments.  This fixes the `atexit.register()` call to include the required args expected by `object.__exit__()`.

Change introduced in Ape framework in PR https://github.com/ApeWorX/ape/pull/1733

### How I did it

`None`

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
