### PR TITLE
fix: task ID and persistence discrepancy

### DIFF
--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -21,6 +21,7 @@ def resolve_task(message: TaskiqMessage) -> Tuple[str, Optional[int], Optional[i
     elif "event" in task_id:
         block_number = message.args[0].block_number
         log_index = message.args[0].log_index
+        # TODO: Should standardize on event signature here instead of name in case of overloading
         task_id = handler_id_event(message.args[0].contract_address, message.args[0].event_name)
 
     return task_id, block_number, log_index

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -18,7 +18,7 @@ def resolve_task(message: TaskiqMessage) -> Tuple[str, Optional[int], Optional[i
     if task_id == "block":
         block_number = message.args[0].number
         task_id = handler_id_block(block_number)
-    elif task_id == "event":
+    elif "event" in task_id:
         block_number = message.args[0].block_number
         log_index = message.args[0].log_index
         task_id = handler_id_event(message.args[0].address, message.args[0].abi.name)

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -21,7 +21,7 @@ def resolve_task(message: TaskiqMessage) -> Tuple[str, Optional[int], Optional[i
     elif "event" in task_id:
         block_number = message.args[0].block_number
         log_index = message.args[0].log_index
-        task_id = handler_id_event(message.args[0].address, message.args[0].abi.name)
+        task_id = handler_id_event(message.args[0].contract_address, message.args[0].abi.name)
 
     return task_id, block_number, log_index
 

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -21,7 +21,7 @@ def resolve_task(message: TaskiqMessage) -> Tuple[str, Optional[int], Optional[i
     elif "event" in task_id:
         block_number = message.args[0].block_number
         log_index = message.args[0].log_index
-        task_id = handler_id_event(message.args[0].contract_address, message.args[0].abi.name)
+        task_id = handler_id_event(message.args[0].contract_address, message.args[0].event_name)
 
     return task_id, block_number, log_index
 

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -39,4 +39,4 @@ def handler_id_block(block_number: Optional[int]) -> str:
 def handler_id_event(contract_address: Optional[str], event_signature: str) -> str:
     """Return a unique handler ID string for an event"""
     # TODO: Under what circumstance can address be None?
-    return f"event/{contract_address or 'unknown'}/{event_signature}"
+    return f"{contract_address or 'unknown'}/event/{event_signature}"


### PR DESCRIPTION
### What I did

Fixes a minor discrepancy between handler_id and task_id.  This caused log_index and block number to not be set.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
