### PR TITLE
fix: add workaround for adhoc networks

### DIFF
--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -77,6 +77,10 @@ class Settings(BaseSettings, ManagerAccessMixin):
         return persistence_class()
 
     def get_provider_context(self) -> ProviderContextManager:
+        # NOTE: Bit of a workaround for adhoc connections:
+        #       https://github.com/ApeWorX/ape/issues/1762
+        if "adhoc" in self.get_network_choice():
+            return ProviderContextManager(provider=self.provider)
         return self.network_manager.parse_network_choice(self.get_network_choice())
 
     def get_signer(self) -> Optional[AccountAPI]:


### PR DESCRIPTION
### What I did

Fixed an edge case where `self.network_manager.network.choice` on the `ManagerAccessMixin` isn't a valid network choice for `parse_network_choice()`.  

Ref: https://github.com/ApeWorX/ape/issues/1762

### How I did it

Added a bit of a workaround here since the adhoc network will have already been configured by a network bound command.

### How to verify it

Run Silverback programmatically via a `NetworkBoundCommand`

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
