### PR TITLE
fix: encode/decode bytes/HexBytes recursively in messages

### DIFF
--- a/silverback/utils.py
+++ b/silverback/utils.py
@@ -38,13 +38,17 @@ def async_wrap_iter(it: Iterator) -> AsyncIterator:
     return yield_queue_items()
 
 
-def hexbytes_dict(data: dict) -> dict:
+def hexbytes_dict(data: dict, recurse_count: int = 0) -> dict:
     """Converts any hex string values in a flat dictionary to HexBytes."""
     fixed_data = {}
 
     for name, value in data.items():
         if isinstance(value, str) and value.startswith("0x"):
             fixed_data[name] = HexBytes(value)
+        elif isinstance(value, dict):
+            if recurse_count > 3:
+                raise RecursionError("Event object is too deep")
+            hexbytes_dict(value, recurse_count + 1)
         else:
             fixed_data[name] = value
 


### PR DESCRIPTION
### What I did

Made the message encoding/decoding in middleware recurisve, lest any mildly complex messages with bytes in them break the whole thing.

### How I did it

![](https://media1.tenor.com/m/EzI8667iX68AAAAC/stare-into.gif)

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
