### PR TITLE
feat: adds @cron task decorator

### DIFF
--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -59,6 +59,19 @@ Inside of `handle_token_transfer_events` you can define any logic that you want 
 Again, you can return any serializable data structure from this function and that will be stored in the results database as a trackable metric for the execution of this handler.
 Any errors you raise during this function will get captured by the client, and recorded as a failure to handle this `transfer` event log.
 
+## Cron Tasks
+
+You may also want to run some tasks according to a schedule, either for efficiency reasons or just that the task is not related to any chain-driven events.
+You can do that with the `@cron` task decorator.
+
+```python
+@app.cron("* */1 * * *")
+def every_hour():
+    ...
+```
+
+For more information see [the linux handbook section on the crontab syntax](https://linuxhandbook.com/crontab/#understanding-crontab-syntax) or the [crontab.guru](https://crontab.guru/) generator.
+
 ## Startup and Shutdown
 
 ### Worker Events

--- a/example.py
+++ b/example.py
@@ -1,4 +1,5 @@
-from typing import Annotated
+from datetime import datetime
+from typing import Annotated  # NOTE: Only Python 3.9+
 
 from ape import chain
 from ape.api import BlockAPI
@@ -36,6 +37,12 @@ def worker_startup(state: TaskiqState):  # NOTE: You need the type hint here
     state.db = MyDB()
     state.block_count = 0
     # raise Exception  # NOTE: Any exception raised on worker startup aborts immediately
+
+
+# You can run cron jobs in your apps (functions that execute at a regular time period)
+@app.cron("*/5 * * * *")
+def every_five_minutes():
+    return {"crontime": datetime.utcnow()}
 
 
 # This is how we trigger off of new blocks

--- a/example.py
+++ b/example.py
@@ -40,8 +40,9 @@ def worker_startup(state: TaskiqState):  # NOTE: You need the type hint here
 
 
 # You can run cron jobs in your apps (functions that execute at a regular time period)
-@app.cron("*/5 * * * *")
-def every_five_minutes():
+# NOTE: Great for things like regular DB cleanups or producing metrics at regular intervals
+@app.cron("*/2 * * * *")
+def every_two_minutes():
     return {"crontime": datetime.utcnow()}
 
 

--- a/example.py
+++ b/example.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Annotated  # NOTE: Only Python 3.9+
+from typing import Annotated
 
 from ape import chain
 from ape.api import BlockAPI

--- a/example.py
+++ b/example.py
@@ -42,8 +42,8 @@ def worker_startup(state: TaskiqState):  # NOTE: You need the type hint here
 # You can run cron jobs in your apps (functions that execute at a regular time period)
 # NOTE: Great for things like regular DB cleanups or producing metrics at regular intervals
 @app.cron("*/2 * * * *")
-def every_two_minutes():
-    return {"crontime": datetime.utcnow()}
+def every_two_minutes(current_time_utc: datetime):
+    return {"crontime": current_time_utc}
 
 
 # This is how we trigger off of new blocks

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -32,6 +32,9 @@ class TaskData(BaseModel):
 
     # NOTE: Any other items here must have a default value
 
+    def __hash__(self):
+        return hash(self.name)  # NOTE: Name should be unique, okay for hashing
+
 
 class SilverbackApp(ManagerAccessMixin):
     """

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -1,4 +1,5 @@
 import asyncio
+import traceback
 from abc import ABC, abstractmethod
 
 from ape import chain
@@ -283,9 +284,11 @@ class BaseRunner(ABC):
         tasks_with_errors, tasks_running = await asyncio.wait(
             listener_tasks, return_when=asyncio.FIRST_EXCEPTION
         )
-        if runtime_errors := "\n".join(str(task.exception()) for task in tasks_with_errors):
+        if runtime_errors := "\n\n".join(
+            "".join(traceback.format_exception(task.exception())) for task in tasks_with_errors
+        ):
             # NOTE: In case we are somehow not displaying the error correctly with task status
-            logger.debug(f"Runtime error(s) detected, shutting down:\n{runtime_errors}")
+            logger.warning(f"Runtime error(s) detected, shutting down\n{runtime_errors}")
 
         # Cancel any still running
         (task.cancel() for task in tasks_running)

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -16,15 +16,13 @@ from .exceptions import Halt, NoTasksAvailableError, NoWebsocketAvailableError, 
 from .recorder import BaseRecorder, TaskResult
 from .state import AppDatastore, AppState
 from .subscriptions import SubscriptionType, Web3SubscriptionsManager
-from .types import CronSchedule, TaskType, utc_now
+from .types import CRON_CHECK_SECONDS, CronSchedule, TaskType, utc_now
 from .utils import (
     async_wrap_iter,
     hexbytes_dict,
     run_taskiq_task_group_wait_results,
     run_taskiq_task_wait_result,
 )
-
-CRON_CHECK_SECONDS = 5
 
 
 class BaseRunner(ABC):

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -135,7 +135,7 @@ class BaseRunner(ABC):
                 td for td, cron in cron_jobs.items() if cron.is_ready(current_time)
             ]:
                 tasks = await asyncio.gather(
-                    *((self._create_task_kicker(td).kiq() for td in task_data_to_kiq))
+                    *((self._create_task_kicker(td).kiq(current_time) for td in task_data_to_kiq))
                 )
                 await asyncio.gather(*(self._handle_task(task) for task in tasks))
 

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -61,18 +61,13 @@ class CronSchedule(BaseModel):
 
     def __init__(self, cron: str = "", **field_values):
         if cron:
-            field_values = dict(
-                zip(
-                    iter(self.__fields__),  # type: ignore[call-overload]
-                    cron.split(" "),
-                )
-            )
+            field_values = dict(zip(self.model_fields, cron.split(" ")))
 
         super().__init__(**field_values)
 
     @model_serializer
     def create_cron_string(self) -> str:
-        return " ".join(map(lambda f: getattr(self, f), self.__fields__))
+        return " ".join(map(lambda f: getattr(self, f), self.model_fields))
 
     def __str__(self) -> str:
         return self.create_cron_string()

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -49,6 +49,9 @@ UTCTimestamp = Annotated[
 ]
 
 
+CRON_CHECK_SECONDS = 5
+
+
 class CronSchedule(BaseModel):
     minute: str
     hour: str
@@ -100,6 +103,7 @@ class CronSchedule(BaseModel):
     def is_ready(self, current_time: datetime) -> bool:
         return all(
             [
+                abs(current_time.second) < CRON_CHECK_SECONDS,  # NOTE: Ensure close to :00 seconds
                 self._check_value(self.minute, current_time.minute),
                 self._check_value(self.hour, current_time.hour),
                 self._check_value(self.day_month, current_time.day),

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -88,7 +88,7 @@ class CronSchedule(BaseModel):
             matches = list(map(int, val.split(",")))
 
         elif val == "*":
-            return current % step == 0
+            return current % step == step - 1
 
         else:
             matches = [int(val)]
@@ -103,7 +103,7 @@ class CronSchedule(BaseModel):
                 self._check_value(self.hour, current_time.hour),
                 self._check_value(self.day_month, current_time.day),
                 self._check_value(self.month, current_time.month),
-                self._check_value(self.day_week, current_time.weekday()),
+                self._check_value(self.day_week, current_time.weekday() + 1),
             ]
         )
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,8 +1,28 @@
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import pytest
 
-from silverback.types import Datapoints
+from silverback.types import CRON_CHECK_SECONDS, CronSchedule, Datapoints
+
+
+@pytest.mark.parametrize(
+    "cron_schedule,current_time_str",
+    [
+        ("5 0 * 8 *", "2024-08-01 00:05"),
+        ("0 22 * * 1-5", "2024-06-03 22:00"),
+        ("23 0-20/2 * * *", "2024-06-03 20:23"),
+        ("0 0,12 1 */2 *", "2024-07-01 00:00"),
+        ("0 4 8-14 * *", "2024-06-08 04:00"),
+        ("0 0 1,15 * 3", "2024-06-05 00:00"),
+    ],
+)
+def test_cron_is_ready(cron_schedule, current_time_str):
+    current_time = datetime.fromisoformat(current_time_str)
+    cron = CronSchedule(cron=cron_schedule)
+    assert cron.is_ready(current_time)
+    current_time += timedelta(seconds=CRON_CHECK_SECONDS)
+    assert not cron.is_ready(current_time)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### What I did

Adds the `@cron` task decorator so we can execute arbitrary tasks according to a crontab schedule.

### How I did it

Adds an event loop to the runner that checks if cron tasks should be executes.  If true, it will kiq the tasks off.

### How to verify it

```python
@app.cron("*/5 * * * *")
def every_five_minutes():
    return {"crontime": datetime.utcnow()}
```

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
