### PR TITLE
fix: if BROKER_URI is not defined, give the constructor None

### DIFF
--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -46,7 +46,8 @@ class Settings(BaseSettings, ManagerAccessMixin):
             broker = broker_class()
 
         else:
-            broker = broker_class(self.BROKER_URI)
+            # TODO: Not all brokers share a common arg signature.
+            broker = broker_class(self.BROKER_URI or None)
 
         middlewares: List[TaskiqMiddleware] = [SilverbackMiddleware(silverback_settings=self)]
 


### PR DESCRIPTION
### What I did

Prevents an empty string from being given to a broker class if `SILVERBACK_BROKER_URI` is not defined.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
