### PR TITLE
fix(devops): grant write perms to docs job in workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
     docs:
         runs-on: ubuntu-latest
+        permissions:
+          contents: write
 
         steps:
         - uses: actions/checkout@v3


### PR DESCRIPTION
### What I did

This will (probably) fix [the issue updating the repo seen in this job run](https://github.com/ApeWorX/silverback/actions/runs/8454906985/job/23161106159).

### How I did it

Grants write perms to the job.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
