### PR TITLE
fix(devops): adds write perms to drafter workflow

### DIFF
--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - uses: release-drafter/release-drafter@v5


### PR DESCRIPTION
### What I did

And [another one](https://github.com/ApeWorX/silverback/actions/runs/8458155621/job/23171743638).

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
