### PR TITLE
feat!: add data acquisition to recorders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ version.py
 
 # Ape stuff
 .build/
+.silverback-sessions/
 
 **/.DS_Store
 *.swp

--- a/example.py
+++ b/example.py
@@ -6,7 +6,7 @@ from ape.types import ContractLog
 from ape_tokens import tokens  # type: ignore[import]
 from taskiq import Context, TaskiqDepends, TaskiqState
 
-from silverback import CircuitBreaker, SilverbackApp
+from silverback import AppState, CircuitBreaker, SilverbackApp
 
 # Do this first to initialize your app
 app = SilverbackApp()
@@ -17,11 +17,11 @@ YFI = tokens["YFI"]
 
 
 @app.on_startup()
-def app_startup():
+def app_startup(startup_state: AppState):
     # NOTE: This is called just as the app is put into "run" state,
     #       and handled by the first available worker
     # raise Exception  # NOTE: Any exception raised on startup aborts immediately
-    return {"block_number": app.state.last_block_seen}
+    return {"block_number": startup_state.last_block_seen}
 
 
 # Can handle some resource initialization for each worker, like LLMs or database connections

--- a/example.py
+++ b/example.py
@@ -46,7 +46,7 @@ def exec_block(block: BlockAPI, state: WorkerState):
 
 # This is how we trigger off of events
 # Set new_block_timeout to adjust the expected block time.
-@app.on_(USDC.Transfer, start_block=18588777, new_block_timeout=25)
+@app.on_(USDC.Transfer, start_block=19784367, new_block_timeout=25)
 # NOTE: Typing isn't required, it will still be an Ape `ContractLog` type
 def exec_event1(log):
     if log.log_index % 7 == 3:

--- a/example.py
+++ b/example.py
@@ -1,14 +1,11 @@
-from typing import Annotated
-
 from ape import chain
 from ape.api import BlockAPI
 from ape.types import ContractLog
 from ape_tokens import tokens  # type: ignore[import]
-from taskiq import Context, TaskiqDepends, TaskiqState
 
-from silverback import CircuitBreaker, SilverbackApp, SilverbackStartupState
+from silverback import CircuitBreaker, SilverbackApp, WorkerState
 
-# Do this to initialize your app
+# Do this first to initialize your app
 app = SilverbackApp()
 
 # NOTE: Don't do any networking until after initializing app
@@ -17,53 +14,68 @@ YFI = tokens["YFI"]
 
 
 @app.on_startup()
-def app_startup(startup_state: SilverbackStartupState):
-    return {"message": "Starting...", "block_number": startup_state.last_block_seen}
+def app_startup():
+    # NOTE: This is called just as the app is put into "run" state,
+    #       and handled by the first available worker
+    # raise Exception  # NOTE: Any exception raised on startup aborts immediately
+    return {"block_number": app.state.last_block_seen}
 
 
-# Can handle some initialization on startup, like models or network connections
+# Can handle some resource initialization for each worker, like LLMs or database connections
+class MyDB:
+    def execute(self, query: str):
+        pass
+
+
 @app.on_worker_startup()
-def worker_startup(state: TaskiqState):
+def worker_startup(state: WorkerState):  # NOTE: You need the type hint here
+    # NOTE: Can put anything here, any python object works
+    state.db = MyDB()
     state.block_count = 0
-    # state.db = MyDB()
-    return {"message": "Worker started."}
+    # raise Exception  # NOTE: Any exception raised on worker startup aborts immediately
 
 
 # This is how we trigger off of new blocks
 @app.on_(chain.blocks)
-# context must be a type annotated kwarg to be provided to the task
-def exec_block(block: BlockAPI, context: Annotated[Context, TaskiqDepends()]):
-    context.state.block_count += 1
+# NOTE: The type hint for block is `BlockAPI`, but we parse it using `EcosystemAPI`
+# NOTE: If you need something from worker state, you have to use the type hint
+def exec_block(block: BlockAPI, state: WorkerState):
+    state.db.execute(f"some query {block.number}")
     return len(block.transactions)
 
 
 # This is how we trigger off of events
 # Set new_block_timeout to adjust the expected block time.
 @app.on_(USDC.Transfer, start_block=18588777, new_block_timeout=25)
-# NOTE: Typing isn't required
+# NOTE: Typing isn't required, it will still be an Ape `ContractLog` type
 def exec_event1(log):
     if log.log_index % 7 == 3:
-        # If you ever want the app to shutdown under some scenario, call this exception
-        raise CircuitBreaker("Oopsie!")
+        # If you raise any exception, Silverback will track the failure and keep running
+        # NOTE: By default, if you have 3 tasks fail in a row, the app will shutdown itself
+        raise ValueError("I don't like the number 3.")
+
     return {"amount": log.amount}
 
 
 @app.on_(YFI.Approval)
 # Any handler function can be async too
 async def exec_event2(log: ContractLog):
+    if log.log_index % 7 == 6:
+        # If you ever want the app to immediately shutdown under some scenario, raise this exception
+        raise CircuitBreaker("Oopsie!")
+
     return log.amount
-
-
-# Just in case you need to release some resources or something
-@app.on_worker_shutdown()
-def worker_shutdown(state):
-    return {
-        "message": f"Worker stopped after handling {state.block_count} blocks.",
-        "block_count": state.block_count,
-    }
 
 
 # A final job to execute on Silverback shutdown
 @app.on_shutdown()
-def app_shutdown(state):
-    return {"message": "Stopping..."}
+def app_shutdown():
+    # raise Exception  # NOTE: Any exception raised on shutdown is ignored
+    return {"block_number": app.state.last_block_processed}
+
+
+# Just in case you need to release some resources or something inside each worker
+@app.on_worker_shutdown()
+def worker_shutdown(state):
+    state.db = None
+    # raise Exception  # NOTE: Any exception raised on worker shutdown is ignored

--- a/example.py
+++ b/example.py
@@ -74,7 +74,7 @@ async def exec_event2(log: ContractLog):
 @app.on_shutdown()
 def app_shutdown():
     # raise Exception  # NOTE: Any exception raised on shutdown is ignored
-    return {"block_number": app.state.last_block_processed}
+    return {"some_metric": 123}
 
 
 # Just in case you need to release some resources or something inside each worker

--- a/silverback/__init__.py
+++ b/silverback/__init__.py
@@ -1,10 +1,10 @@
 from .application import SilverbackApp
 from .exceptions import CircuitBreaker, SilverbackException
-from .types import SilverbackStartupState
+from .types import WorkerState
 
 __all__ = [
     "CircuitBreaker",
     "SilverbackApp",
     "SilverbackException",
-    "SilverbackStartupState",
+    "WorkerState",
 ]

--- a/silverback/__init__.py
+++ b/silverback/__init__.py
@@ -1,10 +1,8 @@
 from .application import SilverbackApp
 from .exceptions import CircuitBreaker, SilverbackException
-from .types import WorkerState
 
 __all__ = [
     "CircuitBreaker",
     "SilverbackApp",
     "SilverbackException",
-    "WorkerState",
 ]

--- a/silverback/__init__.py
+++ b/silverback/__init__.py
@@ -1,7 +1,9 @@
 from .application import SilverbackApp
 from .exceptions import CircuitBreaker, SilverbackException
+from .state import AppState
 
 __all__ = [
+    "AppState",
     "CircuitBreaker",
     "SilverbackApp",
     "SilverbackException",

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -46,9 +46,9 @@ class SilverbackApp(ManagerAccessMixin):
         if not settings:
             settings = Settings()
 
-        network = settings.get_provider_context()
+        provider_context = settings.get_provider_context()
         # NOTE: This allows using connected ape methods e.g. `Contract`
-        provider = network.__enter__()
+        provider = provider_context.__enter__()
 
         self.identifier = SilverbackID(
             name=settings.APP_NAME,
@@ -70,7 +70,7 @@ class SilverbackApp(ManagerAccessMixin):
         self.tasks: defaultdict[TaskType, list[TaskData]] = defaultdict(list)
         self.poll_settings: dict[str, dict] = {}
 
-        atexit.register(network.__exit__, None, None, None)
+        atexit.register(provider_context.__exit__, None, None, None)
 
         self.signer = settings.get_signer()
         self.new_block_timeout = settings.NEW_BLOCK_TIMEOUT

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -131,7 +131,7 @@ class SilverbackApp(ManagerAccessMixin):
                 # Address is almost a certainty if the container is being used as a filter here.
                 if contract_address := getattr(container.contract, "address", None):
                     labels["contract_address"] = contract_address
-                labels["event_signature"] = container.abi.signature
+                labels["event_signature"] = f'"{container.abi.signature}"'
 
             broker_task = self.broker.register_task(
                 handler,

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -131,6 +131,7 @@ class SilverbackApp(ManagerAccessMixin):
                 # Address is almost a certainty if the container is being used as a filter here.
                 if contract_address := getattr(container.contract, "address", None):
                     labels["contract_address"] = contract_address
+                # NOTE: event signature is a string with spaces/commas, so encapsulate it in quotes
                 labels["event_signature"] = f'"{container.abi.signature}"'
 
             broker_task = self.broker.register_task(

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -88,8 +88,6 @@ class SilverbackApp(ManagerAccessMixin):
             f"{signer_str}{start_block_str}{new_block_timeout_str}"
         )
 
-        self.state = None  # Runner manages this
-
     def broker_task_decorator(
         self,
         task_type: TaskType,

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -134,8 +134,7 @@ class SilverbackApp(ManagerAccessMixin):
                 # Address is almost a certainty if the container is being used as a filter here.
                 if contract_address := getattr(container.contract, "address", None):
                     labels["contract_address"] = contract_address
-                # NOTE: event signature is a string with spaces/commas, so encapsulate it in quotes
-                labels["event_signature"] = f'"{container.abi.signature}"'
+                labels["event_signature"] = f"{container.abi.signature}"
 
             broker_task = self.broker.register_task(
                 handler,

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -124,7 +124,10 @@ class SilverbackApp(ManagerAccessMixin):
         def add_taskiq_task(handler: Callable) -> AsyncTaskiqDecoratedTask:
             labels = {"task_type": str(task_type)}
 
-            if container and isinstance(container, ContractEvent):
+            # NOTE: Do *not* do `if container` because that does a `len(container)` call,
+            #       which for ContractEvent queries *every single log* ever emitted, and really
+            #       we only want to determine if it is not None
+            if container is not None and isinstance(container, ContractEvent):
                 # Address is almost a certainty if the container is being used as a filter here.
                 if contract_address := getattr(container.contract, "address", None):
                     labels["contract_address"] = contract_address

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -46,9 +46,11 @@ class SilverbackApp(ManagerAccessMixin):
         if not settings:
             settings = Settings()
 
-        self.network = settings.get_provider_context()
+        self.name = settings.APP_NAME
+
+        network = settings.get_provider_context()
         # NOTE: This allows using connected ape methods e.g. `Contract`
-        provider = self.network.__enter__()
+        provider = network.__enter__()
 
         # Adjust defaults from connection
         if settings.NEW_BLOCK_TIMEOUT is None and (
@@ -64,22 +66,24 @@ class SilverbackApp(ManagerAccessMixin):
         self.tasks: defaultdict[TaskType, list[TaskData]] = defaultdict(list)
         self.poll_settings: dict[str, dict] = {}
 
-        atexit.register(self.network.__exit__, None, None, None)
+        atexit.register(network.__exit__, None, None, None)
 
         self.signer = settings.get_signer()
         self.new_block_timeout = settings.NEW_BLOCK_TIMEOUT
         self.start_block = settings.START_BLOCK
 
-        network_str = f'\n  NETWORK="{provider.network.ecosystem.name}:{provider.network.name}"'
+        self.network_choice = f"{provider.network.ecosystem.name}:{provider.network.name}"
         signer_str = f"\n  SIGNER={repr(self.signer)}"
         start_block_str = f"\n  START_BLOCK={self.start_block}" if self.start_block else ""
         new_block_timeout_str = (
             f"\n  NEW_BLOCK_TIMEOUT={self.new_block_timeout}" if self.new_block_timeout else ""
         )
         logger.info(
-            f"Loaded Silverback App:{network_str}"
+            f'Loaded Silverback App:\n  NETWORK="{self.network_choice}"'
             f"{signer_str}{start_block_str}{new_block_timeout_str}"
         )
+
+        self.state = None  # Runner manages this
 
     def broker_task_decorator(
         self,

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from ape.exceptions import ApeException
-from ape.logging import logger
 
 from .types import TaskType
 
@@ -36,9 +35,8 @@ class Halt(SilverbackException):
         super().__init__("App halted, must restart manually")
 
 
-class CircuitBreaker(SilverbackException):
+class CircuitBreaker(Halt):
     """Custom exception (created by user) that will trigger an application shutdown."""
 
     def __init__(self, message: str):
-        logger.error(message)
-        super().__init__(message)
+        super(SilverbackException, self).__init__(message)

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Sequence
 
 from ape.exceptions import ApeException
 
@@ -28,6 +28,20 @@ class NoWebsocketAvailableError(Exception):
 
 class SilverbackException(ApeException):
     """Base Exception for any Silverback runtime faults."""
+
+
+# TODO: `ExceptionGroup` added in Python 3.11
+class StartupFailure(SilverbackException):
+    def __init__(self, *exceptions: Sequence[Exception]):
+        if error_str := "\n".join(str(e) for e in exceptions):
+            super().__init__(f"Startup failure(s):\n{error_str}")
+        else:
+            super().__init__("Startup failure(s) detected. See logs for details.")
+
+
+class NoTasksAvailableError(SilverbackException):
+    def __init__(self):
+        super().__init__("No tasks to execute")
 
 
 class Halt(SilverbackException):

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -56,8 +56,10 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
         # NOTE: Ensure we always have this, no matter what
         message.labels["task_name"] = message.task_name
 
-        if not (task_type_str := message.labels.pop("task_type")):
+        if "task_type" not in message.labels:
             return message  # Not a silverback task
+
+        task_type_str = message.labels.pop("task_type")
 
         try:
             task_type = TaskType(task_type_str)

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -53,14 +53,14 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
             return message.task_name
 
     def pre_execute(self, message: TaskiqMessage) -> TaskiqMessage:
-        if "task_type" not in message.labels:
-            return message  # Not a silverback task
-
-        task_type = message.labels.pop("task_type")
+        # NOTE: Ensure we always have this, no matter what
         message.labels["task_name"] = message.task_name
 
+        if not (task_type_str := message.labels.pop("task_type")):
+            return message  # Not a silverback task
+
         try:
-            task_type = TaskType(task_type)
+            task_type = TaskType(task_type_str)
         except ValueError:
             return message  # Not a silverback task
 

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -45,7 +45,10 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
 
     def _create_label(self, message: TaskiqMessage) -> str:
         if labels_str := ",".join(
-            f"{k}={v}" for k, v in message.labels.items() if k != "task_name"
+            # NOTE: Have to add extra quotes around event signatures so they display as a string
+            f"{k}={v}" if k != "event_signature" else f'{k}="{v}"'
+            for k, v in message.labels.items()
+            if k != "task_name"
         ):
             return f"{message.task_name}[{labels_str}]"
 

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -44,7 +44,9 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
         return message
 
     def _create_label(self, message: TaskiqMessage) -> str:
-        if labels_str := ",".join(f"{k}={v}" for k, v in message.labels.items()):
+        if labels_str := ",".join(
+            f"{k}={v}" for k, v in message.labels.items() if k != "task_name"
+        ):
             return f"{message.task_name}[{labels_str}]"
 
         else:
@@ -55,6 +57,7 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
             return message  # Not a silverback task
 
         task_type = message.labels.pop("task_type")
+        message.labels["task_name"] = message.task_name
 
         try:
             task_type = TaskType(task_type)

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -6,8 +6,7 @@ from ape.utils import ManagerAccessMixin
 from eth_utils.conversions import to_hex
 from taskiq import TaskiqMessage, TaskiqMiddleware, TaskiqResult
 
-from silverback.recorder import HandlerResult
-from silverback.types import SilverbackID, TaskType
+from silverback.types import TaskType
 from silverback.utils import hexbytes_dict
 
 
@@ -22,11 +21,7 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
 
             return int((head.timestamp - genesis.timestamp) / head.number)
 
-        settings = kwargs.pop("silverback_settings")
-
         self.block_time = self.chain_manager.provider.network.block_time or compute_block_time()
-        self.ident = SilverbackID.from_settings(settings)
-        self.recorder = settings.get_recorder()
 
     def pre_send(self, message: TaskiqMessage) -> TaskiqMessage:
         # TODO: Necessary because bytes/HexBytes doesn't encode/deocde well for some reason
@@ -96,22 +91,5 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
         (logger.error if result.error else logger.success)(
             f"{self._create_label(message)} " f"- {result.execution_time:.3f}s{percent_display}"
         )
-
-    async def post_save(self, message: TaskiqMessage, result: TaskiqResult):
-        if not self.recorder:
-            return
-
-        handler_result = HandlerResult.from_taskiq(
-            self.ident,
-            message.task_name,
-            message.labels.get("block_number"),
-            message.labels.get("log_index"),
-            result,
-        )
-
-        try:
-            await self.recorder.add_result(handler_result)
-        except Exception as err:
-            logger.error(f"Error storing result: {err}")
 
     # NOTE: Unless stdout is ignored, error traceback appears in stdout, no need for `on_error`

--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -53,7 +53,6 @@ class TaskResult(BaseModel):
             logger.warning(f"Cannot handle return type of '{task_name}': '{type(result)}'.")
             return {}
 
-        # else:
         converted_result = {}
 
         for metric_name, metric_value in result.items():

--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -151,7 +151,7 @@ class JSONLineRecorder(BaseRecorder):
 
     To use this recorder, you must configure the following environment variable:
 
-    - `SILVERBACK_RECORDER_CLASS`: `"silverback.recorder.JSONLineRecorder"`
+    - `SILVERBACK_RECORDER_CLASS`: `"silverback.recorder:JSONLineRecorder"`
 
     You may also want to give your app a unique name so the data does not get overwritten,
     if you are using multiple apps from the same directory:

--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -3,13 +3,14 @@ import os
 import sqlite3
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
-from typing import TypeVar
+from typing import Any, TypeVar
 
-from pydantic import BaseModel
+from ape.logging import get_logger
+from pydantic import BaseModel, Field
 from taskiq import TaskiqResult
 from typing_extensions import Self  # Introduced 3.11
 
-from .types import SilverbackID
+from .types import BaseDatapoint, Metrics, ScalarDatapoint, SilverbackID, scalar_types
 
 _HandlerReturnType = TypeVar("_HandlerReturnType")
 
@@ -24,13 +25,44 @@ class SilverbackState(BaseModel):
     updated: datetime
 
 
-class HandlerResult(TaskiqResult):
+class HandlerResult(BaseModel):
     instance: str
     network: str
     handler_id: str
     block_number: int | None
     log_index: int | None
     created: datetime
+    labels: dict[str, Any] = Field(default_factory=dict)
+    execution_time: float
+    metrics: Metrics
+    error: Optional[str] = None
+
+    @classmethod
+    def _extract_metrics(cls, result: Any, handler_id: str) -> Metrics:
+        if isinstance(result, BaseDatapoint):
+            return {f"{handler_id}_result": result}
+
+        elif isinstance(result, scalar_types):
+            return {f"{handler_id}_result": ScalarDatapoint(data=result)}
+
+        elif isinstance(result, dict):
+            converted_result = {
+                k: ScalarDatapoint(data=v) if not isinstance(v, BaseDatapoint) else v
+                for k, v in result.items()
+                if isinstance(v, (BaseDatapoint, *scalar_types))
+            }
+            if len(converted_result) < len(result):
+                logger = get_logger(handler_id)
+                logger.warning(f"Unhandled results: {len(result)-len(converted_result)}")
+
+            return converted_result
+
+        elif result is not None:
+            logger = get_logger(handler_id)
+            logger.warning(f"Cannot handle return type '{type(result.metrics)}'.")
+
+        # else:
+        return {}
 
     @classmethod
     def from_taskiq(
@@ -48,7 +80,10 @@ class HandlerResult(TaskiqResult):
             block_number=block_number,
             log_index=log_index,
             created=datetime.now(timezone.utc),
-            **result.dict(),
+            labels=result.labels,
+            execution_time=result.execution_time,
+            error=str(result.error),
+            metrics=cls._extract_metrics(result.return_value, handler_id),
         )
 
 
@@ -113,16 +148,16 @@ class SQLiteRecorder(BaseRecorder):
         WHERE instance = ? AND network = ?;
     """
     SQL_GET_RESULT_LATEST = """
-        SELECT handler_id, block_number, log_index, execution_time, is_err, created,
-            return_value_blob
+        SELECT handler_id, block_number, log_index, execution_time, error, created,
+            metrics_blob
         FROM silverback_result
         WHERE instance = ? AND network = ?
         ORDER BY created DESC
         LIMIT 1;
     """
     SQL_GET_HANDLER_LATEST = """
-        SELECT handler_id, block_number, log_index, execution_time, is_err, created,
-            return_value_blob
+        SELECT handler_id, block_number, log_index, execution_time, error, created,
+            metrics_blob
         FROM silverback_result
         WHERE instance = ? AND network = ? AND handler_id = ?
         ORDER BY created DESC
@@ -131,7 +166,7 @@ class SQLiteRecorder(BaseRecorder):
     SQL_INSERT_RESULT = """
         INSERT INTO silverback_result (
             instance, network, handler_id, block_number, log_index, execution_time,
-            is_err, created, return_value_blob
+            error, created, metrics_blob
         )
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
     """
@@ -160,9 +195,9 @@ class SQLiteRecorder(BaseRecorder):
                 block_number int,
                 log_index int,
                 execution_time real,
-                is_err bool,
+                error text,
                 created int,
-                return_value_blob blob
+                metrics_blob blob
             );
             CREATE UNIQUE INDEX IF NOT EXISTS silverback_state__instance
                 ON silverback_state(instance, network);
@@ -170,8 +205,8 @@ class SQLiteRecorder(BaseRecorder):
                 ON silverback_result (instance, network);
             CREATE INDEX IF NOT EXISTS silverback_result__handler
                 ON silverback_result (instance, network, handler_id);
-            CREATE INDEX IF NOT EXISTS silverback_result__is_err
-                ON silverback_result (is_err);
+            CREATE INDEX IF NOT EXISTS silverback_result__error
+                ON silverback_result (error);
             COMMIT;
         """
         )
@@ -295,9 +330,9 @@ class SQLiteRecorder(BaseRecorder):
             block_number=row[1],
             log_index=row[2],
             execution_time=row[3],
-            is_err=row[4],
+            error=row[4],
             created=datetime.fromtimestamp(row[5], timezone.utc),
-            return_value=json.loads(row[6]),
+            metrics=json.loads(row[6]),
         )
 
     async def add_result(self, v: HandlerResult):
@@ -317,9 +352,9 @@ class SQLiteRecorder(BaseRecorder):
                 v.block_number,
                 v.log_index,
                 v.execution_time,
-                v.is_err,
+                v.error,
                 v.created,
-                json.dumps(v.return_value),
+                json.dumps({n: m.model_dump_json() for n, m in v.metrics.items()}),
             ),
         )
 

--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -74,7 +74,7 @@ class TaskResult(BaseModel):
     def _extract_system_metrics(cls, labels: dict) -> dict:
         metrics = {}
 
-        if block_number := labels.get("number") or labels.get("block"):
+        if block_number := labels.get("block_number"):
             metrics["block_number"] = int(block_number)
 
         return metrics

--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -10,9 +10,19 @@ from pydantic import BaseModel, Field
 from taskiq import TaskiqResult
 from typing_extensions import Self  # Introduced 3.11
 
-from .types import BaseDatapoint, Metrics, ScalarDatapoint, SilverbackID, scalar_types
+from .types import (
+    Datapoint,
+    ScalarDatapoint,
+    ScalarType,
+    SilverbackID,
+    UTCTimestamp,
+    iso_format,
+    utc_now,
+)
 
 _HandlerReturnType = TypeVar("_HandlerReturnType")
+
+logger = get_logger(__name__)
 
 
 class SilverbackState(BaseModel):
@@ -25,65 +35,77 @@ class SilverbackState(BaseModel):
     updated: datetime
 
 
-class HandlerResult(BaseModel):
-    instance: str
-    network: str
-    handler_id: str
-    block_number: int | None
-    log_index: int | None
-    created: datetime
-    labels: dict[str, Any] = Field(default_factory=dict)
+class TaskResult(BaseModel):
+    # NOTE: Model must eventually serialize using PyArrow/Parquet for long-term storage
+
+    # Task Info
+    task_name: str
     execution_time: float
-    metrics: Metrics
-    error: Optional[str] = None
+    error: str | None = None
+
+    # NOTE: intended to use default when creating a model with this type
+    completed: UTCTimestamp = Field(default_factory=utc_now)
+
+    # System Metrics here (must default to None in case they are missing)
+    block_number: int | None = None
+
+    # Custom user metrics here
+    metrics: dict[str, Datapoint] = {}
 
     @classmethod
-    def _extract_metrics(cls, result: Any, handler_id: str) -> Metrics:
-        if isinstance(result, BaseDatapoint):
-            return {f"{handler_id}_result": result}
+    def _extract_custom_metrics(cls, result: Any, task_name: str) -> dict[str, Datapoint]:
+        if isinstance(result, Datapoint):  # type: ignore[arg-type,misc]
+            return {"result": result}
 
-        elif isinstance(result, scalar_types):
-            return {f"{handler_id}_result": ScalarDatapoint(data=result)}
+        elif isinstance(result, ScalarType):  # type: ignore[arg-type,misc]
+            return {"result": ScalarDatapoint(data=result)}
 
-        elif isinstance(result, dict):
-            converted_result = {
-                k: ScalarDatapoint(data=v) if not isinstance(v, BaseDatapoint) else v
-                for k, v in result.items()
-                if isinstance(v, (BaseDatapoint, *scalar_types))
-            }
-            if len(converted_result) < len(result):
-                logger = get_logger(handler_id)
-                logger.warning(f"Unhandled results: {len(result)-len(converted_result)}")
+        elif result is None:
+            return {}
 
-            return converted_result
-
-        elif result is not None:
-            logger = get_logger(handler_id)
-            logger.warning(f"Cannot handle return type '{type(result.metrics)}'.")
+        elif not isinstance(result, dict):
+            logger.warning(f"Cannot handle return type of '{task_name}': '{type(result)}'.")
+            return {}
 
         # else:
-        return {}
+        converted_result = {}
+
+        for metric_name, metric_value in result.items():
+            if isinstance(metric_value, Datapoint):  # type: ignore[arg-type,misc]
+                converted_result[metric_name] = metric_value
+
+            elif isinstance(metric_value, ScalarType):  # type: ignore[arg-type,misc]
+                converted_result[metric_name] = ScalarDatapoint(data=metric_value)
+
+            else:
+                logger.warning(
+                    f"Cannot handle type of metric '{task_name}.{metric_name}':"
+                    f" '{type(metric_value)}'."
+                )
+
+        return converted_result
+
+    @classmethod
+    def _extract_system_metrics(cls, labels: dict) -> dict:
+        metrics = {}
+
+        if block_number := labels.get("number") or labels.get("block"):
+            metrics["block_number"] = int(block_number)
+
+        return metrics
 
     @classmethod
     def from_taskiq(
         cls,
-        ident: SilverbackID,
-        handler_id: str,
-        block_number: int | None,
-        log_index: int | None,
         result: TaskiqResult,
     ) -> Self:
+        task_name = result.labels.pop("task_name", "<unknown>")
         return cls(
-            instance=ident.identifier,
-            network=ident.network_choice,
-            handler_id=handler_id,
-            block_number=block_number,
-            log_index=log_index,
-            created=datetime.now(timezone.utc),
-            labels=result.labels,
+            task_name=task_name,
             execution_time=result.execution_time,
-            error=str(result.error),
-            metrics=cls._extract_metrics(result.return_value, handler_id),
+            error=str(result.error) if result.error else None,
+            metrics=cls._extract_custom_metrics(result.return_value, task_name),
+            **cls._extract_system_metrics(result.labels),
         )
 
 

--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -1,9 +1,6 @@
-import json
-import os
-import sqlite3
 from abc import ABC, abstractmethod
-from datetime import datetime, timezone
-from typing import Any, TypeVar
+from pathlib import Path
+from typing import Any, Iterator
 
 from ape.logging import get_logger
 from pydantic import BaseModel, Field
@@ -11,6 +8,7 @@ from taskiq import TaskiqResult
 from typing_extensions import Self  # Introduced 3.11
 
 from .types import (
+    AppState,
     Datapoint,
     ScalarDatapoint,
     ScalarType,
@@ -20,19 +18,7 @@ from .types import (
     utc_now,
 )
 
-_HandlerReturnType = TypeVar("_HandlerReturnType")
-
 logger = get_logger(__name__)
-
-
-class SilverbackState(BaseModel):
-    instance: str
-    network: str
-    # Last block number seen by runner
-    last_block_seen: int
-    # Last block number processed by a worker
-    last_block_processed: int
-    updated: datetime
 
 
 class TaskResult(BaseModel):
@@ -110,275 +96,104 @@ class TaskResult(BaseModel):
 
 
 class BaseRecorder(ABC):
-    @abstractmethod
-    async def init(self):
-        """Handle any async initialization from Silverback settings (e.g. migrations)."""
-        ...
-
-    @abstractmethod
-    async def get_state(self, ident: SilverbackID) -> SilverbackState | None:
-        """Return the stored state for a Silverback instance"""
-        ...
-
-    @abstractmethod
-    async def set_state(
-        self, ident: SilverbackID, last_block_seen: int, last_block_processed: int
-    ) -> SilverbackState | None:
-        """Set the stored state for a Silverback instance"""
-        ...
-
-    @abstractmethod
-    async def get_latest_result(
-        self, ident: SilverbackID, handler: str | None = None
-    ) -> HandlerResult | None:
-        """Return the latest result for a Silverback instance's handler"""
-        ...
-
-    @abstractmethod
-    async def add_result(self, v: HandlerResult):
-        """Store a result for a Silverback instance's handler"""
-        ...
-
-
-class SQLiteRecorder(BaseRecorder):
     """
-    SQLite implementation of BaseRecorder used to store application state and handler
-    result data.
+    Base class used for managing persistent application state, and serializing task results
+    to an external data recording process.
+
+    NOTE: Persistent state and task results can be managed using two different solutions
+
+    Recorders are configured using the following environment variable:
+
+    - `SILVERBACK_RECORDER_CLASS`: Any fully qualified subclass of `BaseRecorder` as a string
+    """
+
+    @abstractmethod
+    async def init(self, app_id: SilverbackID) -> AppState | None:
+        """
+        Handle any async initialization from Silverback settings (e.g. migrations).
+
+        Returns startup state, if available.
+        """
+
+    @abstractmethod
+    async def set_state(self, app_state: AppState):
+        """Set the stored state for a Silverback instance"""
+
+    @abstractmethod
+    async def add_result(self, result: TaskResult):
+        """Store a result for a Silverback instance's handler"""
+
+
+class JSONLineRecorder(BaseRecorder):
+    """
+    Very basic implementation of BaseRecorder used to store application state and handler
+    result data by storing/retreiving state from a JSON-encoded file, and appending task
+    results to a file containing newline-separated JSON entries (https://jsonlines.org/).
+
+    The file structure that this Recorder uses leverages the value of `SILVERBACK_APP_NAME`
+    as well as the configured network to determine the location where files get saved:
+
+        ./.silverback-sessions/
+          <app-name>/
+            <network choice>/
+              state.json  # always write here
+              session-<timestamp>.json  # start time of each app session
+
+    Each app "session" (everytime the Runner is started up via `silverback run`) is recorded
+    in a separate file with the timestamp of the first handled task in its filename.
+
+    Note that this format can be read by basic means (even in a JS frontend), or read
+    efficiently via Apache Arrow for more efficient big data processing:
+
+        https://arrow.apache.org/docs/python/json.html
 
     Usage:
 
-    To use SQLite recorder, you must configure the following env vars:
+    To use this recorder, you must configure the following environment variable:
 
-    - `RECORDER_CLASS`: `silverback.recorder.SQLiteRecorder`
-    - `SQLITE_PATH` (optional): A system file path or if blank it will be stored in-memory.
+    - `SILVERBACK_RECORDER_CLASS`: `"silverback.recorder.JSONLineRecorder"`
+
+    You may also want to give your app a unique name so the data does not get overwritten,
+    if you are using multiple apps from the same directory:
+
+    - `SILVERBACK_APP_NAME`: Any alphabetical string valid as a folder name
     """
 
-    SQL_GET_STATE = """
-        SELECT last_block_seen, last_block_processed, updated
-        FROM silverback_state
-        WHERE instance = ? AND network = ?;
-    """
-    SQL_INSERT_STATE = """
-        INSERT INTO silverback_state (
-            instance, network, last_block_seen, last_block_processed, updated
+    async def init(self, app_id: SilverbackID) -> AppState | None:
+        data_folder = (
+            Path.cwd() / ".silverback-sessions" / app_id.name / app_id.ecosystem / app_id.network
         )
-        VALUES (?, ?, ?, ?, ?);
-    """
-    SQL_UPDATE_STATE = """
-        UPDATE silverback_state
-        SET last_block_seen = ?, last_block_processed = ?, updated = ?
-        WHERE instance = ? AND network = ?;
-    """
-    SQL_GET_RESULT_LATEST = """
-        SELECT handler_id, block_number, log_index, execution_time, error, created,
-            metrics_blob
-        FROM silverback_result
-        WHERE instance = ? AND network = ?
-        ORDER BY created DESC
-        LIMIT 1;
-    """
-    SQL_GET_HANDLER_LATEST = """
-        SELECT handler_id, block_number, log_index, execution_time, error, created,
-            metrics_blob
-        FROM silverback_result
-        WHERE instance = ? AND network = ? AND handler_id = ?
-        ORDER BY created DESC
-        LIMIT 1;
-    """
-    SQL_INSERT_RESULT = """
-        INSERT INTO silverback_result (
-            instance, network, handler_id, block_number, log_index, execution_time,
-            error, created, metrics_blob
-        )
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);
-    """
+        data_folder.mkdir(parents=True, exist_ok=True)
 
-    con: sqlite3.Connection | None
-    initialized: bool = False
+        self.state_backup_file = data_folder / "state.json"
+        self.session_results_file = data_folder / f"session-{iso_format(utc_now())}.jsonl"
 
-    async def init(self):
-        self.con = sqlite3.connect(os.environ.get("SQLITE_PATH", ":memory:"))
-
-        cur = self.con.cursor()
-        cur.executescript(
-            """
-            BEGIN;
-            CREATE TABLE IF NOT EXISTS silverback_state (
-                instance text,
-                network text,
-                last_block_seen int,
-                last_block_processed int,
-                updated int
-            );
-            CREATE TABLE IF NOT EXISTS silverback_result (
-                instance text,
-                network text,
-                handler_id text,
-                block_number int,
-                log_index int,
-                execution_time real,
-                error text,
-                created int,
-                metrics_blob blob
-            );
-            CREATE UNIQUE INDEX IF NOT EXISTS silverback_state__instance
-                ON silverback_state(instance, network);
-            CREATE INDEX IF NOT EXISTS silverback_result__instance
-                ON silverback_result (instance, network);
-            CREATE INDEX IF NOT EXISTS silverback_result__handler
-                ON silverback_result (instance, network, handler_id);
-            CREATE INDEX IF NOT EXISTS silverback_result__error
-                ON silverback_result (error);
-            COMMIT;
-        """
-        )
-        cur.close()
-
-        if not self.con:
-            raise Exception("Failed to setup SQLite connection")
-
-        self.initialized = True
-
-    async def get_state(self, ident: SilverbackID) -> SilverbackState | None:
-        if not self.initialized:
-            await self.init()
-
-        assert self.con is not None
-
-        cur = self.con.cursor()
-        res = cur.execute(
-            self.SQL_GET_STATE,
-            (ident.identifier, ident.network_choice),
-        )
-        row = res.fetchone()
-
-        cur.close()
-
-        if row is None:
-            return None
-
-        return SilverbackState(
-            instance=ident.identifier,
-            network=ident.network_choice,
-            last_block_seen=row[0],
-            last_block_processed=row[1],
-            updated=datetime.fromtimestamp(row[2], timezone.utc),
+        return (
+            AppState.parse_file(self.state_backup_file) if self.state_backup_file.exists() else None
         )
 
-    async def set_state(
-        self, ident: SilverbackID, last_block_seen: int, last_block_processed: int
-    ) -> SilverbackState | None:
-        if not self.initialized:
-            await self.init()
+    async def set_state(self, state: AppState):
+        self.state_backup_file.write_text(state.model_dump_json())
 
-        assert self.con is not None
+    async def add_result(self, result: TaskResult):
+        # NOTE: mode `a` means "append to file if exists"
+        # NOTE: JSONNL convention requires the use of `\n` as newline char
+        with self.session_results_file.open("a") as writer:
+            writer.write(result.model_dump_json())
+            writer.write("\n")
 
-        cur = self.con.cursor()
-        res = cur.execute(
-            self.SQL_GET_STATE,
-            (ident.identifier, ident.network_choice),
-        )
-        row = res.fetchone()
 
-        now = datetime.now(timezone.utc)
-        now_stamp = int(now.timestamp())
-
-        if row is None:
-            cur.execute(
-                self.SQL_INSERT_STATE,
-                (
-                    ident.identifier,
-                    ident.network_choice,
-                    last_block_seen,
-                    last_block_processed,
-                    now_stamp,
-                ),
-            )
-        else:
-            cur.execute(
-                self.SQL_UPDATE_STATE,
-                (
-                    last_block_seen,
-                    last_block_processed,
-                    now_stamp,
-                    ident.identifier,
-                    ident.network_choice,
-                ),
-            )
-
-        cur.close()
-        self.con.commit()
-
-        return SilverbackState(
-            instance=ident.identifier,
-            network=ident.network_choice,
-            last_block_seen=last_block_seen,
-            last_block_processed=last_block_processed,
-            updated=now,
-        )
-
-    async def get_latest_result(
-        self, ident: SilverbackID, handler: str | None = None
-    ) -> HandlerResult | None:
-        if not self.initialized:
-            await self.init()
-
-        assert self.con is not None
-
-        cur = self.con.cursor()
-
-        if handler is not None:
-            res = cur.execute(
-                self.SQL_GET_HANDLER_LATEST,
-                (ident.identifier, ident.network_choice, handler),
-            )
-        else:
-            res = cur.execute(
-                self.SQL_GET_RESULT_LATEST,
-                (ident.identifier, ident.network_choice),
-            )
-
-        row = res.fetchone()
-
-        cur.close()
-
-        if row is None:
-            return None
-
-        return HandlerResult(
-            instance=ident.identifier,
-            network=ident.network_choice,
-            handler_id=row[0],
-            block_number=row[1],
-            log_index=row[2],
-            execution_time=row[3],
-            error=row[4],
-            created=datetime.fromtimestamp(row[5], timezone.utc),
-            metrics=json.loads(row[6]),
-        )
-
-    async def add_result(self, v: HandlerResult):
-        if not self.initialized:
-            await self.init()
-
-        assert self.con is not None
-
-        cur = self.con.cursor()
-
-        cur.execute(
-            self.SQL_INSERT_RESULT,
-            (
-                v.instance,
-                v.network,
-                v.handler_id,
-                v.block_number,
-                v.log_index,
-                v.execution_time,
-                v.error,
-                v.created,
-                json.dumps({n: m.model_dump_json() for n, m in v.metrics.items()}),
-            ),
-        )
-
-        cur.close()
-        self.con.commit()
+def get_metrics(session: Path | str, task_name: str) -> Iterator[dict]:
+    with open(session, "r") as file:
+        for line in file:
+            if (
+                (result := TaskResult.model_validate_json(line))
+                and result.task_name == task_name
+                and not result.error
+            ):
+                yield {
+                    "block_number": result.block_number,
+                    "execution_time": result.execution_time,
+                    "completed": result.completed,
+                    **{name: datapoint.data for name, datapoint in result.metrics.items()},
+                }

--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -183,7 +183,7 @@ class JSONLineRecorder(BaseRecorder):
             writer.write("\n")
 
 
-def get_metrics(session: Path | str, task_name: str) -> Iterator[dict]:
+def get_metrics(session: Path, task_name: str) -> Iterator[dict]:
     with open(session, "r") as file:
         for line in file:
             if (

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -13,7 +13,7 @@ from .exceptions import Halt, NoTasksAvailableError, NoWebsocketAvailableError, 
 from .recorder import BaseRecorder, TaskResult
 from .state import AppDatastore, AppState
 from .subscriptions import SubscriptionType, Web3SubscriptionsManager
-from .types import SilverbackID, TaskType
+from .types import TaskType
 from .utils import async_wrap_iter, hexbytes_dict
 
 

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -35,10 +35,11 @@ class BaseRunner(ABC):
             self.exceptions += 1
 
         else:
+            # NOTE: Reset exception counter
             self.exceptions = 0
 
         if self.exceptions > self.max_exceptions:
-            raise Halt()
+            raise Halt() from result.error
 
     async def _checkpoint(
         self, last_block_seen: int = 0, last_block_processed: int = 0

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -31,13 +31,6 @@ class BaseRunner(ABC):
         self.max_exceptions = max_exceptions
         self.exceptions = 0
 
-        ecosystem_name, network_name = app.network_choice.split(":")
-        self.identifier = SilverbackID(
-            name=app.name,
-            ecosystem=ecosystem_name,
-            network=network_name,
-        )
-
         logger.info(f"Using {self.__class__.__name__}: max_exceptions={self.max_exceptions}")
 
     async def _handle_task(self, task: AsyncTaskiqTask):
@@ -111,7 +104,7 @@ class BaseRunner(ABC):
                 If there are no configured tasks to execute.
         """
         # Initialize recorder (if available) and fetch state if app has been run previously
-        if self.recorder and (startup_state := (await self.recorder.init(app_id=self.identifier))):
+        if self.recorder and (startup_state := (await self.recorder.init(app_id=self.app.identifier))):
             self.app.state = startup_state
 
         else:  # use empty state

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -22,7 +22,7 @@ class BaseRunner(ABC):
         app: SilverbackApp,
         *args,
         max_exceptions: int = 3,
-        recorder: Optional[BaseRecorder] = None,
+        recorder: BaseRecorder | None = None,
         **kwargs,
     ):
         self.app = app

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings, ManagerAccessMixin):
     """
 
     # A unique identifier for this silverback instance
-    INSTANCE: str = "default"
+    APP_NAME: str = "bot"
 
     BROKER_CLASS: str = "taskiq:InMemoryBroker"
     BROKER_URI: str = ""

--- a/silverback/state.py
+++ b/silverback/state.py
@@ -1,0 +1,62 @@
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from .types import SilverbackID, UTCTimestamp, utc_now
+
+
+class AppState(BaseModel):
+    # Last block number seen by runner
+    last_block_seen: int
+
+    # Last block number processed by a worker
+    last_block_processed: int
+
+    # Last time the state was updated
+    # NOTE: intended to use default when creating a model with this type
+    last_updated: UTCTimestamp = Field(default_factory=utc_now)
+
+
+class AppDatastore:
+    """
+    Very basic implementation used to store application state and handler result data by
+    storing/retreiving state from a JSON-encoded file.
+
+    The file structure that this Recorder uses leverages the value of `SILVERBACK_APP_NAME`
+    as well as the configured network to determine the location where files get saved:
+
+        ./.silverback-sessions/
+          <app-name>/
+            <network choice>/
+              state.json  # always write here
+
+    Note that this format can be read by basic means (even in a JS frontend):
+
+    You may also want to give your app a unique name so the data does not get overwritten,
+    if you are using multiple apps from the same directory:
+
+    - `SILVERBACK_APP_NAME`: Any alphabetical string valid as a folder name
+    """
+
+    async def init(self, app_id: SilverbackID) -> AppState | None:
+        data_folder = (
+            Path.cwd() / ".silverback-sessions" / app_id.name / app_id.ecosystem / app_id.network
+        )
+        data_folder.mkdir(parents=True, exist_ok=True)
+
+        self.state_backup_file = data_folder / "state.json"
+
+        return (
+            AppState.parse_file(self.state_backup_file) if self.state_backup_file.exists() else None
+        )
+
+    async def set_state(self, state: AppState):
+        if self.state_backup_file.exists():
+            old_state = AppState.parse_file(self.state_backup_file)
+            if old_state.last_block_seen > state.last_block_seen:
+                state.last_block_seen = old_state.last_block_seen
+            if old_state.last_block_processed > state.last_block_processed:
+                state.last_block_processed = old_state.last_block_processed
+
+        state.last_updated = utc_now()
+        self.state_backup_file.write_text(state.model_dump_json())

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.functional_serializers import PlainSerializer
 from typing_extensions import Annotated
 
@@ -43,8 +43,10 @@ class _BaseDatapoint(BaseModel):
     type: str  # discriminator
 
 
+# NOTE: Maximum supported parquet integer type: https://parquet.apache.org/docs/file-format/types
+Int96 = Annotated[int, Field(ge=-(2**95), le=2**95 - 1)]
 # NOTE: only these types of data are implicitly converted e.g. `{"something": 1, "else": 0.001}`
-ScalarType = bool | int | float | Decimal
+ScalarType = bool | Int96 | float | Decimal
 
 
 class ScalarDatapoint(_BaseDatapoint):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,11 +1,12 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
-from typing import Annotated, Literal, Union
+from typing import Literal, Union
 
 from pydantic import BaseModel, Field
 from pydantic.functional_serializers import PlainSerializer
 from taskiq import Context, TaskiqDepends, TaskiqState
+from typing_extensions import Annotated  # Introduced 3.9
 
 
 class TaskType(str, Enum):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -5,7 +5,6 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 from pydantic.functional_serializers import PlainSerializer
-from taskiq import Context, TaskiqDepends, TaskiqState
 from typing_extensions import Annotated
 
 
@@ -50,13 +49,6 @@ class AppState(BaseModel):
     # Last time the state was updated
     # NOTE: intended to use default when creating a model with this type
     last_updated: UTCTimestamp = Field(default_factory=utc_now)
-
-
-def get_worker_state(context: Annotated[Context, TaskiqDepends()]) -> TaskiqState:
-    return context.state
-
-
-WorkerState = Annotated[TaskiqState, TaskiqDepends(get_worker_state)]
 
 
 class _BaseDatapoint(BaseModel):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from pydantic.functional_serializers import PlainSerializer
 from typing_extensions import Annotated
 
@@ -37,18 +37,6 @@ UTCTimestamp = Annotated[
     # TODO: Bug in TaskIQ can't serialize `datetime`
     PlainSerializer(iso_format, return_type=str),
 ]
-
-
-class AppState(BaseModel):
-    # Last block number seen by runner
-    last_block_seen: int
-
-    # Last block number processed by a worker
-    last_block_processed: int
-
-    # Last time the state was updated
-    # NOTE: intended to use default when creating a model with this type
-    last_updated: UTCTimestamp = Field(default_factory=utc_now)
 
 
 class _BaseDatapoint(BaseModel):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Union
 
 from pydantic import BaseModel, Field
 from pydantic.functional_serializers import PlainSerializer
@@ -63,7 +63,7 @@ class _BaseDatapoint(BaseModel):
 
 
 # NOTE: only these types of data are implicitly converted e.g. `{"something": 1, "else": 0.001}`
-ScalarType = bool | int | float | Decimal
+ScalarType = Union[bool, int, float, Decimal]
 
 
 class ScalarDatapoint(_BaseDatapoint):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,7 +1,9 @@
+from datetime import datetime, timezone
+from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
-from typing import Protocol
+from typing import Literal, Protocol, get_args
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing_extensions import Self  # Introduced 3.11
 
 
@@ -38,3 +40,26 @@ class SilverbackID(BaseModel):
 class SilverbackStartupState(BaseModel):
     last_block_seen: int
     last_block_processed: int
+
+
+class BaseDatapoint(BaseModel):
+    type: str  # discriminator
+
+    # NOTE: default value ensures we don't have to set this manually
+    time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+ScalarType = bool | int | float | Decimal
+scalar_types = get_args(ScalarType)
+
+
+class ScalarDatapoint(BaseDatapoint):
+    type: Literal["scalar"] = "scalar"
+
+    # NOTE: app-supported scalar value types:
+    data: ScalarType
+
+
+# This is what a Silverback app task must return to integrate properly with our data acq system
+Metrics = dict[str, BaseDatapoint]
+# Otherwise, log a warning and ignore any unconverted return value(s)

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
-from typing import Literal, Union
+from typing import Literal
 
 from pydantic import BaseModel, Field
 from pydantic.functional_serializers import PlainSerializer
@@ -64,7 +64,7 @@ class _BaseDatapoint(BaseModel):
 
 
 # NOTE: only these types of data are implicitly converted e.g. `{"something": 1, "else": 0.001}`
-ScalarType = Union[bool, int, float, Decimal]
+ScalarType = bool | int | float | Decimal
 
 
 class ScalarDatapoint(_BaseDatapoint):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -6,14 +6,14 @@ from typing import Literal
 from pydantic import BaseModel, Field
 from pydantic.functional_serializers import PlainSerializer
 from taskiq import Context, TaskiqDepends, TaskiqState
-from typing_extensions import Annotated  # Introduced 3.9
+from typing_extensions import Annotated
 
 
 class TaskType(str, Enum):
-    STARTUP = "silverback_startup"  # TODO: Shorten in 0.4.0
+    STARTUP = "startup"
     NEW_BLOCKS = "block"
     EVENT_LOG = "event"
-    SHUTDOWN = "silverback_shutdown"  # TODO: Shorten in 0.4.0
+    SHUTDOWN = "shutdown"
 
     def __str__(self) -> str:
         return self.value


### PR DESCRIPTION
### What I did

Refactors the structure of `HandlerResult` to add support for serialized data structures for metrics

Makes a breaking change deprecating `SQLiteRecorder` in favor of `JSONLineRecorder`

Makes a breaking change to annotated Worker state and App state

Makes a larger refactor of `BaseRunner.run` startup sequence to reduce errant errors and give better logging

Adds a callback to allow configuring a recorder in `silverback run` command, and pipes that to `BaseRunner`

related: #59 

~~requires: #63, #66 (for proper labeling of results)~~

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
