### PR TITLE
refactor: allow multiple handlers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup(
         "eth-pydantic-types",  # Use same version as eth-ape
         "pydantic_settings",  # Use same version as eth-ape
         "taskiq[metrics]>=0.10.4,<0.11.0",
+        "backports.strenum ; python_version<'3.11'",
     ],
     entry_points={
         "console_scripts": ["silverback=silverback._cli:cli"],

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(
         "eth-pydantic-types",  # Use same version as eth-ape
         "pydantic_settings",  # Use same version as eth-ape
         "taskiq[metrics]>=0.10.4,<0.11.0",
-        "backports.strenum ; python_version<'3.11'",
     ],
     entry_points={
         "console_scripts": ["silverback=silverback._cli:cli"],

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -139,7 +139,7 @@ class SilverbackApp(ManagerAccessMixin):
             def do_something_on_startup(startup_state):
                 ...  # Reprocess missed events or blocks
         """
-        return self.broker_task_decorator(TaskType.STARTUP)
+        return self.broker_task_decorator(TaskType.STARTUP)  # type: ignore[arg-type]
 
     def on_shutdown(self) -> Callable:
         """
@@ -151,7 +151,7 @@ class SilverbackApp(ManagerAccessMixin):
             def do_something_on_shutdown():
                 ...  # Record final state of app
         """
-        return self.broker_task_decorator(TaskType.SHUTDOWN)
+        return self.broker_task_decorator(TaskType.SHUTDOWN)  # type: ignore[arg-type]
 
     def on_worker_startup(self) -> Callable:
         """
@@ -210,7 +210,10 @@ class SilverbackApp(ManagerAccessMixin):
                 else:
                     self.poll_settings["_blocks_"] = {"start_block": start_block}
 
-            return self.broker_task_decorator(TaskType.NEW_BLOCKS, container=container)
+            return self.broker_task_decorator(
+                TaskType.NEW_BLOCKS,  # type: ignore[arg-type]
+                container=container,
+            )
 
         elif isinstance(container, ContractEvent) and isinstance(
             container.contract, ContractInstance
@@ -229,7 +232,10 @@ class SilverbackApp(ManagerAccessMixin):
                 else:
                     self.poll_settings[key] = {"start_block": start_block}
 
-            return self.broker_task_decorator(TaskType.EVENT_LOG, container=container)
+            return self.broker_task_decorator(
+                TaskType.EVENT_LOG,  # type: ignore[arg-type]
+                container=container,
+            )
 
         # TODO: Support account transaction polling
         # TODO: Support mempool polling

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -7,7 +7,6 @@ from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.contracts import ContractEvent, ContractInstance
 from ape.logging import logger
 from ape.managers.chain import BlockContainer
-from ape.types import AddressType
 from ape.utils import ManagerAccessMixin
 from taskiq import AsyncTaskiqDecoratedTask, TaskiqEvents
 
@@ -18,7 +17,7 @@ from .types import TaskType
 
 @dataclass
 class Task:
-    container: BlockContainer | ContractEvent | None
+    container: Union[BlockContainer, ContractEvent, None]
     handler: AsyncTaskiqDecoratedTask
 
 
@@ -101,7 +100,7 @@ class SilverbackApp(ManagerAccessMixin):
     def broker_task_decorator(
         self,
         task_type: TaskType,
-        container: BlockContainer | ContractEvent | None = None,
+        container: Union[BlockContainer, ContractEvent, None] = None,
     ):
         def add_taskiq_task(handler: Callable):
             # TODO: Support generic registration

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -139,7 +139,7 @@ class SilverbackApp(ManagerAccessMixin):
             def do_something_on_startup(startup_state):
                 ...  # Reprocess missed events or blocks
         """
-        return self.broker_task_decorator(TaskType.STARTUP)  # type: ignore[arg-type]
+        return self.broker_task_decorator(TaskType.STARTUP)
 
     def on_shutdown(self) -> Callable:
         """
@@ -151,7 +151,7 @@ class SilverbackApp(ManagerAccessMixin):
             def do_something_on_shutdown():
                 ...  # Record final state of app
         """
-        return self.broker_task_decorator(TaskType.SHUTDOWN)  # type: ignore[arg-type]
+        return self.broker_task_decorator(TaskType.SHUTDOWN)
 
     def on_worker_startup(self) -> Callable:
         """
@@ -210,10 +210,7 @@ class SilverbackApp(ManagerAccessMixin):
                 else:
                     self.poll_settings["_blocks_"] = {"start_block": start_block}
 
-            return self.broker_task_decorator(
-                TaskType.NEW_BLOCKS,  # type: ignore[arg-type]
-                container=container,
-            )
+            return self.broker_task_decorator(TaskType.NEW_BLOCKS, container=container)
 
         elif isinstance(container, ContractEvent) and isinstance(
             container.contract, ContractInstance
@@ -232,10 +229,7 @@ class SilverbackApp(ManagerAccessMixin):
                 else:
                     self.poll_settings[key] = {"start_block": start_block}
 
-            return self.broker_task_decorator(
-                TaskType.EVENT_LOG,  # type: ignore[arg-type]
-                container=container,
-            )
+            return self.broker_task_decorator(TaskType.EVENT_LOG, container=container)
 
         # TODO: Support account transaction polling
         # TODO: Support mempool polling

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -163,48 +163,6 @@ class SilverbackApp(ManagerAccessMixin):
         """
         return self.broker.on_event(TaskiqEvents.WORKER_SHUTDOWN)
 
-    def get_startup_handler(self) -> Optional[AsyncTaskiqDecoratedTask]:
-        """
-        Get access to the handler for `silverback_startup` events.
-
-        Returns:
-            Optional[AsyncTaskiqDecoratedTask]: Returns decorated task, if one has been created.
-        """
-        return self.broker.find_task("silverback_startup")
-
-    def get_shutdown_handler(self) -> Optional[AsyncTaskiqDecoratedTask]:
-        """
-        Get access to the handler for `silverback_shutdown` events.
-
-        Returns:
-            Optional[AsyncTaskiqDecoratedTask]: Returns decorated task, if one has been created.
-        """
-        return self.broker.find_task("silverback_shutdown")
-
-    def get_block_handler(self) -> Optional[AsyncTaskiqDecoratedTask]:
-        """
-        Get access to the handler for `block` events.
-
-        Returns:
-            Optional[AsyncTaskiqDecoratedTask]: Returns decorated task, if one has been created.
-        """
-        return self.broker.find_task("block")
-
-    def get_event_handler(
-        self, event_target: AddressType, event_name: str
-    ) -> Optional[AsyncTaskiqDecoratedTask]:
-        """
-        Get access to the handler for `<event_target>:<event_name>` events.
-
-        Args:
-            event_target (AddressType): The contract address of the target.
-            event_name: (str): The name of the event emitted by ``event_target``.
-
-        Returns:
-            Optional[AsyncTaskiqDecoratedTask]: Returns decorated task, if one has been created.
-        """
-        return self.broker.find_task(f"{event_target}/event/{event_name}")
-
     def on_(
         self,
         container: Union[BlockContainer, ContractEvent],

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -3,6 +3,8 @@ from typing import Any
 from ape.exceptions import ApeException
 from ape.logging import logger
 
+from .types import TaskType
+
 
 class ImportFromStringError(Exception):
     pass
@@ -11,6 +13,11 @@ class ImportFromStringError(Exception):
 class InvalidContainerTypeError(Exception):
     def __init__(self, container: Any):
         super().__init__(f"Invalid container type: {container.__class__}")
+
+
+class ContainerTypeMismatchError(Exception):
+    def __init__(self, task_type: TaskType, container: Any):
+        super().__init__(f"Invalid container type for '{task_type}': {container.__class__}")
 
 
 class NoWebsocketAvailableError(Exception):

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -8,11 +8,6 @@ class ImportFromStringError(Exception):
     pass
 
 
-class DuplicateHandlerError(Exception):
-    def __init__(self, handler_type: str):
-        super().__init__(f"Only one handler allowed for: {handler_type}")
-
-
 class InvalidContainerTypeError(Exception):
     def __init__(self, container: Any):
         super().__init__(f"Invalid container type: {container.__class__}")

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -85,7 +85,7 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
             message.labels["number"] = str(message.args[0].number)
             message.labels["hash"] = message.args[0].hash.hex()
 
-        elif "event" in message.task_name:
+        elif task_type == TaskType.EVENT_LOG:
             # NOTE: Just in case the user doesn't specify type as `ContractLog`
             message.args[0] = ContractLog.model_validate(message.args[0])
             message.labels["block"] = str(message.args[0].block_number)

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -49,16 +49,13 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
         return message
 
     def _create_label(self, message: TaskiqMessage) -> str:
-        if labels_str := (
-            ",".join(f"{k}={v}" for k, v in message.labels.items() if k != "task_name")
-        ):
+        if labels_str := ",".join(f"{k}={v}" for k, v in message.labels.items()):
             return f"{message.task_name}[{labels_str}]"
 
         else:
             return message.task_name
 
     def pre_execute(self, message: TaskiqMessage) -> TaskiqMessage:
-        message.labels["task_name"] = message.task_name
         task_type = message.labels.pop("task_type", "<unknown>")
 
         # NOTE: Don't compare `str` to `TaskType` using `is`

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -67,18 +67,18 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
         # Add extra labels for our task to see what their source was
         if task_type is TaskType.NEW_BLOCKS:
             # NOTE: Necessary because we don't know the exact block class
-            message.args[0] = self.provider.network.ecosystem.decode_block(
+            block = message.args[0] = self.provider.network.ecosystem.decode_block(
                 hexbytes_dict(message.args[0])
             )
-            message.labels["block_number"] = str(message.args[0].number)
-            message.labels["block_hash"] = message.args[0].hash.hex()
+            message.labels["block_number"] = str(block.number)
+            message.labels["block_hash"] = block.hash.hex()
 
         elif task_type is TaskType.EVENT_LOG:
             # NOTE: Just in case the user doesn't specify type as `ContractLog`
-            message.args[0] = ContractLog.model_validate(message.args[0])
-            message.labels["block_number"] = str(message.args[0].block_number)
-            message.labels["transaction_hash"] = message.args[0].transaction_hash
-            message.labels["log_index"] = str(message.args[0].log_index)
+            log = message.args[0] = ContractLog.model_validate(message.args[0])
+            message.labels["block_number"] = str(log.block_number)
+            message.labels["transaction_hash"] = log.transaction_hash
+            message.labels["log_index"] = str(log.log_index)
 
         logger.debug(f"{self._create_label(message)} - Started")
         return message

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -14,7 +14,7 @@ from .exceptions import Halt, NoWebsocketAvailableError
 from .persistence import BasePersistentStore
 from .settings import Settings
 from .subscriptions import SubscriptionType, Web3SubscriptionsManager
-from .types import SilverbackID, SilverbackStartupState
+from .types import SilverbackID, SilverbackStartupState, TaskType
 from .utils import async_wrap_iter, hexbytes_dict
 
 settings = Settings()
@@ -103,8 +103,8 @@ class BaseRunner(ABC):
         await self.app.broker.startup()
 
         # Execute Silverback startup task before we init the rest
-        if startup_handler := self.app.get_startup_handler():
-            task = await startup_handler.kiq(
+        for startup_task in self.app.tasks.get(TaskType.STARTUP):
+            task = await startup_task.handler.kiq(
                 SilverbackStartupState(
                     last_block_seen=self.last_block_seen,
                     last_block_processed=self.last_block_processed,
@@ -113,15 +113,12 @@ class BaseRunner(ABC):
             result = await task.wait_result()
             self._handle_result(result)
 
-        if block_handler := self.app.get_block_handler():
-            tasks = [self._block_task(block_handler)]
-        else:
-            tasks = []
+        tasks = []
+        for task in self.app.tasks.get(TaskType.NEW_BLOCKS):
+            tasks.append(self._block_task(task.handler))
 
-        for contract_address in self.app.contract_events:
-            for event_name, contract_event in self.app.contract_events[contract_address].items():
-                if event_handler := self.app.get_event_handler(contract_address, event_name):
-                    tasks.append(self._event_task(contract_event, event_handler))
+        for task in self.app.tasks.get(TaskType.EVENT_LOG):
+            tasks.append(self._event_task(task.container, task.handler))
 
         if len(tasks) == 0:
             raise Halt("No tasks to execute")
@@ -129,10 +126,9 @@ class BaseRunner(ABC):
         await asyncio.gather(*tasks)
 
         # Execute Silverback shutdown task before shutting down the broker
-        if shutdown_handler := self.app.get_shutdown_handler():
-            task = await shutdown_handler.kiq()
-            result = await task.wait_result()
-            self._handle_result(result)
+        for shutdown_task in self.app.tasks.get(TaskType.SHUTDOWN):
+            task = await shutdown_task.handler.kiq()
+            result = self._handle_result(await task.wait_result())
 
         await self.app.broker.shutdown()
 

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -103,7 +103,7 @@ class BaseRunner(ABC):
         await self.app.broker.startup()
 
         # Execute Silverback startup task before we init the rest
-        for startup_task in self.app.tasks.get(TaskType.STARTUP):
+        for startup_task in self.app.tasks[TaskType.STARTUP]:
             task = await startup_task.handler.kiq(
                 SilverbackStartupState(
                     last_block_seen=self.last_block_seen,
@@ -114,10 +114,10 @@ class BaseRunner(ABC):
             self._handle_result(result)
 
         tasks = []
-        for task in self.app.tasks.get(TaskType.NEW_BLOCKS):
+        for task in self.app.tasks[TaskType.NEW_BLOCKS]:
             tasks.append(self._block_task(task.handler))
 
-        for task in self.app.tasks.get(TaskType.EVENT_LOG):
+        for task in self.app.tasks[TaskType.EVENT_LOG]:
             tasks.append(self._event_task(task.container, task.handler))
 
         if len(tasks) == 0:
@@ -126,7 +126,7 @@ class BaseRunner(ABC):
         await asyncio.gather(*tasks)
 
         # Execute Silverback shutdown task before shutting down the broker
-        for shutdown_task in self.app.tasks.get(TaskType.SHUTDOWN):
+        for shutdown_task in self.app.tasks[TaskType.SHUTDOWN]:
             task = await shutdown_task.handler.kiq()
             result = self._handle_result(await task.wait_result())
 

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -38,16 +38,3 @@ class SilverbackID(BaseModel):
 class SilverbackStartupState(BaseModel):
     last_block_seen: int
     last_block_processed: int
-
-
-def handler_id_block(block_number: Optional[int]) -> str:
-    """Return a unique handler ID string for a block"""
-    if block_number is None:
-        return "block/pending"
-    return f"block/{block_number}"
-
-
-def handler_id_event(contract_address: Optional[str], event_signature: str) -> str:
-    """Return a unique handler ID string for an event"""
-    # TODO: Under what circumstance can address be None?
-    return f"{contract_address or 'unknown'}/event/{event_signature}"

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -15,10 +15,10 @@ except ImportError:
 
 
 class TaskType(StrEnum):
-    STARTUP = "silverback_startup"  # TODO: Shorten
+    STARTUP = "silverback_startup"  # TODO: Shorten in 0.4.0
     NEW_BLOCKS = "block"
     EVENT_LOG = "event"
-    SHUTDOWN = "silverback_shutdown"  # TODO: Shorten
+    SHUTDOWN = "silverback_shutdown"  # TODO: Shorten in 0.4.0
 
 
 class ISilverbackSettings(Protocol):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,18 +1,24 @@
-from enum import Enum
 from typing import Optional, Protocol
 
 from pydantic import BaseModel
 from typing_extensions import Self  # Introduced 3.11
 
+try:
+    from enum import StrEnum  # Only Python 3.11+
 
-class TaskType(str, Enum):
+except ImportError:
+    from enum import Enum
+
+    class StrEnum(str, Enum):  # type: ignore[no-redef]
+        def __str__(self) -> str:
+            return self.value
+
+
+class TaskType(StrEnum):
     STARTUP = "silverback_startup"  # TODO: Shorten
     NEW_BLOCKS = "block"
     EVENT_LOG = "event"
     SHUTDOWN = "silverback_shutdown"  # TODO: Shorten
-
-    def __str__(self) -> str:
-        return self.value
 
 
 class ISilverbackSettings(Protocol):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -7,11 +7,7 @@ try:
     from enum import StrEnum  # Only Python 3.11+
 
 except ImportError:
-    from enum import Enum
-
-    class StrEnum(str, Enum):  # type: ignore[no-redef]
-        def __str__(self) -> str:
-            return self.value
+    from backports.strenum import StrEnum  # type: ignore[no-redef]
 
 
 class TaskType(StrEnum):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,7 +1,18 @@
+from enum import Enum
 from typing import Optional, Protocol
 
 from pydantic import BaseModel
 from typing_extensions import Self  # Introduced 3.11
+
+
+class TaskType(str, Enum):
+    STARTUP = "silverback_startup"  # TODO: Shorten
+    NEW_BLOCKS = "block"
+    EVENT_LOG = "event"
+    SHUTDOWN = "silverback_shutdown"  # TODO: Shorten
+
+    def __str__(self) -> str:
+        return self.value
 
 
 class ISilverbackSettings(Protocol):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -4,10 +4,11 @@ from pydantic import BaseModel
 from typing_extensions import Self  # Introduced 3.11
 
 try:
-    from enum import StrEnum  # Only Python 3.11+
+    # NOTE: Only Python 3.11+
+    from enum import StrEnum  # type: ignore[attr-defined]
 
 except ImportError:
-    from backports.strenum import StrEnum  # type: ignore[no-redef]
+    from backports.strenum import StrEnum  # type: ignore[no-redef,import-not-found]
 
 
 class TaskType(StrEnum):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,21 +1,18 @@
+from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
 from typing import Optional, Protocol
 
 from pydantic import BaseModel
 from typing_extensions import Self  # Introduced 3.11
 
-try:
-    # NOTE: Only Python 3.11+
-    from enum import StrEnum  # type: ignore[attr-defined]
 
-except ImportError:
-    from backports.strenum import StrEnum  # type: ignore[no-redef,import-not-found]
-
-
-class TaskType(StrEnum):
+class TaskType(str, Enum):
     STARTUP = "silverback_startup"  # TODO: Shorten in 0.4.0
     NEW_BLOCKS = "block"
     EVENT_LOG = "event"
     SHUTDOWN = "silverback_shutdown"  # TODO: Shorten in 0.4.0
+
+    def __str__(self) -> str:
+        return self.value
 
 
 class ISilverbackSettings(Protocol):


### PR DESCRIPTION
### What I did

Refactor to dynamic registration of tasks, saving tasks (and their handlers) in a separate collection that can be accessed via an enum type to specify their class

Relates to https://github.com/ApeWorX/silverback/issues/57, as it migrates to a dynamic registration method via TaskIQ

Also should allow https://github.com/ApeWorX/silverback/pull/55#issuecomment-1977168440 to use dynamic registration to resolve the bug with multiple handlers with different filters not fully registering

### How I did it

New TaskIQ dynamic broker registration API

### How to verify it

Everything should work as it did before, don't think this is breaking but wanted to call attention to commits to make sure they were reviewed fully for breaking behaviors

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
