### PR TITLE
refactor!: drop Python 3.8 & 3.9

### DIFF
--- a/.github/workflows/prtitle.yaml
+++ b/.github/workflows/prtitle.yaml
@@ -17,7 +17,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: "3.10"
 
         - name: Install Dependencies
           run: pip install commitizen

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
                 # TODO: Replace with macos-latest when works again.
                 #   https://github.com/actions/setup-python/issues/808
                 os: [ubuntu-latest, macos-12]   # eventually add `windows-latest`
-                python-version: [3.9, "3.10", "3.11"]
+                python-version: ["3.10", "3.11"]
 
         steps:
         - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
                 # TODO: Replace with macos-latest when works again.
                 #   https://github.com/actions/setup-python/issues/808
                 os: [ubuntu-latest, macos-12]   # eventually add `windows-latest`
-                python-version: [3.8, 3.9, "3.10", "3.11"]
+                python-version: [3.9, "3.10", "3.11"]
 
         steps:
         - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Read the [development userguide](https://docs.apeworx.io/silverback/stable/userg
 
 ## Dependencies
 
-- [python3](https://www.python.org/downloads) version 3.8 or greater, python3-dev
+- [python3](https://www.python.org/downloads) version 3.9 or greater, python3-dev
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Read the [development userguide](https://docs.apeworx.io/silverback/stable/userg
 
 ## Dependencies
 
-- [python3](https://www.python.org/downloads) version 3.9 or greater, python3-dev
+- [python3](https://www.python.org/downloads) version 3.10 or greater, python3-dev
 
 ## Installation
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,6 @@ import re
 import sys
 from functools import lru_cache
 from pathlib import Path
-from typing import List
 
 import requests
 from semantic_version import Version  # type: ignore
@@ -43,7 +42,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns: List[str] = ["_build", ".DS_Store"]
+exclude_patterns: list[str] = ["_build", ".DS_Store"]
 
 
 # The suffix(es) of source filenames.
@@ -94,7 +93,7 @@ def fixpath(path: str) -> str:
 
 
 @lru_cache(maxsize=None)
-def get_versions() -> List[str]:
+def get_versions() -> list[str]:
     """
     Get all the versions from the Web.
     """

--- a/example.py
+++ b/example.py
@@ -1,4 +1,4 @@
-from typing import Annotated  # NOTE: Only Python 3.9+
+from typing import Annotated
 
 from ape import chain
 from ape.api import BlockAPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ write_to = "silverback/version.py"
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py310', 'py311']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "click",  # Use same version as eth-ape
-        "eth-ape>=0.7.0,<1.0",
+        "eth-ape>=0.7,<1.0",
         "ethpm-types>=0.6.10",  # lower pin only, `eth-ape` governs upper pin
         "eth-pydantic-types",  # Use same version as eth-ape
         "pydantic_settings",  # Use same version as eth-ape
@@ -77,7 +77,7 @@ setup(
     entry_points={
         "console_scripts": ["silverback=silverback._cli:cli"],
     },
-    python_requires=">=3.9,<4",
+    python_requires=">=3.10,<4",
     extras_require=extras_require,
     py_modules=["silverback"],
     license="Apache-2.0",
@@ -93,7 +93,6 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     entry_points={
         "console_scripts": ["silverback=silverback._cli:cli"],
     },
-    python_requires=">=3.8,<4",
+    python_requires=">=3.9,<4",
     extras_require=extras_require,
     py_modules=["silverback"],
     license="Apache-2.0",
@@ -93,7 +93,6 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -2,7 +2,7 @@ import atexit
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import timedelta
-from typing import Callable, Dict, Optional, Union
+from typing import Callable
 
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.contracts import ContractEvent, ContractInstance
@@ -18,7 +18,7 @@ from .types import TaskType
 
 @dataclass
 class TaskData:
-    container: Union[BlockContainer, ContractEvent, None]
+    container: BlockContainer | ContractEvent | None
     handler: AsyncTaskiqDecoratedTask
 
 
@@ -35,12 +35,12 @@ class SilverbackApp(ManagerAccessMixin):
         ...  # Connection has been initialized, can call broker methods e.g. `app.on_(...)`
     """
 
-    def __init__(self, settings: Optional[Settings] = None):
+    def __init__(self, settings: Settings | None = None):
         """
         Create app
 
         Args:
-            settings (Optional[~:class:`silverback.settings.Settings`]): Settings override.
+            settings (~:class:`silverback.settings.Settings` | None): Settings override.
                 Defaults to environment settings.
         """
         if not settings:
@@ -62,7 +62,7 @@ class SilverbackApp(ManagerAccessMixin):
         self.broker = settings.get_broker()
         # NOTE: If no tasks registered yet, defaults to empty list instead of raising KeyError
         self.tasks: defaultdict[TaskType, list[TaskData]] = defaultdict(list)
-        self.poll_settings: Dict[str, Dict] = {}
+        self.poll_settings: dict[str, dict] = {}
 
         atexit.register(self.network.__exit__, None, None, None)
 
@@ -84,14 +84,14 @@ class SilverbackApp(ManagerAccessMixin):
     def broker_task_decorator(
         self,
         task_type: TaskType,
-        container: Union[BlockContainer, ContractEvent, None] = None,
+        container: BlockContainer | ContractEvent | None = None,
     ) -> Callable[[Callable], AsyncTaskiqDecoratedTask]:
         """
         Dynamically create a new broker task that handles tasks of ``task_type``.
 
         Args:
             task_type: :class:`~silverback.types.TaskType`: The type of task to create.
-            container: (Union[BlockContainer, ContractEvent]): The event source to watch.
+            container: (BlockContainer | ContractEvent): The event source to watch.
 
         Returns:
             Callable[[Callable], :class:`~taskiq.AsyncTaskiqDecoratedTask`]:
@@ -187,18 +187,18 @@ class SilverbackApp(ManagerAccessMixin):
 
     def on_(
         self,
-        container: Union[BlockContainer, ContractEvent],
-        new_block_timeout: Optional[int] = None,
-        start_block: Optional[int] = None,
+        container: BlockContainer | ContractEvent,
+        new_block_timeout: int | None = None,
+        start_block: int | None = None,
     ):
         """
         Create task to handle events created by `container`.
 
         Args:
-            container: (Union[BlockContainer, ContractEvent]): The event source to watch.
-            new_block_timeout: (Optional[int]): Override for block timeout that is acceptable.
+            container: (BlockContainer | ContractEvent): The event source to watch.
+            new_block_timeout: (int | None): Override for block timeout that is acceptable.
                 Defaults to whatever the app's settings are for default polling timeout are.
-            start_block (Optional[int]): block number to start processing events from.
+            start_block (int | None): block number to start processing events from.
                 Defaults to whatever the latest block is.
 
         Raises:

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -1,6 +1,5 @@
 import asyncio
 from abc import ABC, abstractmethod
-from typing import Optional, Tuple
 
 from ape import chain
 from ape.contracts import ContractEvent, ContractInstance
@@ -28,7 +27,7 @@ class BaseRunner(ABC):
         self.exceptions = 0
         self.last_block_seen = 0
         self.last_block_processed = 0
-        self.recorder: Optional[BaseRecorder] = None
+        self.recorder: BaseRecorder | None = None
         self.ident = SilverbackID.from_settings(settings)
 
     def _handle_result(self, result: TaskiqResult):
@@ -43,7 +42,7 @@ class BaseRunner(ABC):
 
     async def _checkpoint(
         self, last_block_seen: int = 0, last_block_processed: int = 0
-    ) -> Tuple[int, int]:
+    ) -> tuple[int, int]:
         """Set latest checkpoint block number"""
         if (
             last_block_seen > self.last_block_seen

--- a/silverback/subscriptions.py
+++ b/silverback/subscriptions.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from enum import Enum
-from typing import AsyncGenerator, Dict, List, Optional
+from typing import AsyncGenerator
 
 from ape.logging import logger
 from websockets import ConnectionClosedError
@@ -26,10 +26,10 @@ class Web3SubscriptionsManager:
         self._ws_provider_uri = ws_provider_uri
 
         # Stateful
-        self._connection: Optional[ws_client.WebSocketClientProtocol] = None
+        self._connection: ws_client.WebSocketClientProtocol | None = None
         self._last_request: int = 0
-        self._subscriptions: Dict[str, asyncio.Queue] = {}
-        self._rpc_msg_buffer: List[dict] = []
+        self._subscriptions: dict[str, asyncio.Queue] = {}
+        self._rpc_msg_buffer: list[dict] = []
         self._ws_lock = asyncio.Lock()
 
     def __repr__(self) -> str:

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,5 +1,5 @@
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
-from typing import Optional, Protocol
+from typing import Protocol
 
 from pydantic import BaseModel
 from typing_extensions import Self  # Introduced 3.11
@@ -20,7 +20,7 @@ class ISilverbackSettings(Protocol):
     a type reference."""
 
     INSTANCE: str
-    RECORDER_CLASS: Optional[str]
+    RECORDER_CLASS: str | None
 
     def get_network_choice(self) -> str:
         ...


### PR DESCRIPTION
### What I did

It's getting pretty annoying to deal with Python 3.8's missing types, so I just want to drop it in our next breaking release

### How I did it

### How to verify it

### Checklist

- [x] Refactor to take advantage of Python 3.10+ `typing` additons (once some of the bigger PRs merge for next breaking change)
- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
