### PR TITLE
fix: support parquet types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ version.py
 
 # Ape stuff
 .build/
+.silverback-sessions/
 
 **/.DS_Store
 *.swp

--- a/example.py
+++ b/example.py
@@ -1,14 +1,11 @@
-from typing import Annotated  # NOTE: Only Python 3.9+
-
 from ape import chain
 from ape.api import BlockAPI
 from ape.types import ContractLog
 from ape_tokens import tokens  # type: ignore[import]
-from taskiq import Context, TaskiqDepends, TaskiqState
 
-from silverback import CircuitBreaker, SilverbackApp, SilverbackStartupState
+from silverback import CircuitBreaker, SilverbackApp, WorkerState
 
-# Do this to initialize your app
+# Do this first to initialize your app
 app = SilverbackApp()
 
 # NOTE: Don't do any networking until after initializing app
@@ -17,53 +14,68 @@ YFI = tokens["YFI"]
 
 
 @app.on_startup()
-def app_startup(startup_state: SilverbackStartupState):
-    return {"message": "Starting...", "block_number": startup_state.last_block_seen}
+def app_startup():
+    # NOTE: This is called just as the app is put into "run" state,
+    #       and handled by the first available worker
+    # raise Exception  # NOTE: Any exception raised on startup aborts immediately
+    return {"block_number": app.state.last_block_seen}
 
 
-# Can handle some initialization on startup, like models or network connections
+# Can handle some resource initialization for each worker, like LLMs or database connections
+class MyDB:
+    def execute(self, query: str):
+        pass
+
+
 @app.on_worker_startup()
-def worker_startup(state: TaskiqState):
+def worker_startup(state: WorkerState):  # NOTE: You need the type hint here
+    # NOTE: Can put anything here, any python object works
+    state.db = MyDB()
     state.block_count = 0
-    # state.db = MyDB()
-    return {"message": "Worker started."}
+    # raise Exception  # NOTE: Any exception raised on worker startup aborts immediately
 
 
 # This is how we trigger off of new blocks
 @app.on_(chain.blocks)
-# context must be a type annotated kwarg to be provided to the task
-def exec_block(block: BlockAPI, context: Annotated[Context, TaskiqDepends()]):
-    context.state.block_count += 1
+# NOTE: The type hint for block is `BlockAPI`, but we parse it using `EcosystemAPI`
+# NOTE: If you need something from worker state, you have to use the type hint
+def exec_block(block: BlockAPI, state: WorkerState):
+    state.db.execute(f"some query {block.number}")
     return len(block.transactions)
 
 
 # This is how we trigger off of events
 # Set new_block_timeout to adjust the expected block time.
 @app.on_(USDC.Transfer, start_block=18588777, new_block_timeout=25)
-# NOTE: Typing isn't required
+# NOTE: Typing isn't required, it will still be an Ape `ContractLog` type
 def exec_event1(log):
     if log.log_index % 7 == 3:
-        # If you ever want the app to shutdown under some scenario, call this exception
-        raise CircuitBreaker("Oopsie!")
+        # If you raise any exception, Silverback will track the failure and keep running
+        # NOTE: By default, if you have 3 tasks fail in a row, the app will shutdown itself
+        raise ValueError("I don't like the number 3.")
+
     return {"amount": log.amount}
 
 
 @app.on_(YFI.Approval)
 # Any handler function can be async too
 async def exec_event2(log: ContractLog):
+    if log.log_index % 7 == 6:
+        # If you ever want the app to immediately shutdown under some scenario, raise this exception
+        raise CircuitBreaker("Oopsie!")
+
     return log.amount
-
-
-# Just in case you need to release some resources or something
-@app.on_worker_shutdown()
-def worker_shutdown(state):
-    return {
-        "message": f"Worker stopped after handling {state.block_count} blocks.",
-        "block_count": state.block_count,
-    }
 
 
 # A final job to execute on Silverback shutdown
 @app.on_shutdown()
-def app_shutdown(state):
-    return {"message": "Stopping..."}
+def app_shutdown():
+    # raise Exception  # NOTE: Any exception raised on shutdown is ignored
+    return {"block_number": app.state.last_block_processed}
+
+
+# Just in case you need to release some resources or something inside each worker
+@app.on_worker_shutdown()
+def worker_shutdown(state):
+    state.db = None
+    # raise Exception  # NOTE: Any exception raised on worker shutdown is ignored

--- a/silverback/__init__.py
+++ b/silverback/__init__.py
@@ -1,10 +1,10 @@
 from .application import SilverbackApp
 from .exceptions import CircuitBreaker, SilverbackException
-from .types import SilverbackStartupState
+from .types import WorkerState
 
 __all__ = [
     "CircuitBreaker",
     "SilverbackApp",
     "SilverbackException",
-    "SilverbackStartupState",
+    "WorkerState",
 ]

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from ape.exceptions import ApeException
-from ape.logging import logger
 
 from .types import TaskType
 
@@ -36,9 +35,8 @@ class Halt(SilverbackException):
         super().__init__("App halted, must restart manually")
 
 
-class CircuitBreaker(SilverbackException):
+class CircuitBreaker(Halt):
     """Custom exception (created by user) that will trigger an application shutdown."""
 
     def __init__(self, message: str):
-        logger.error(message)
-        super().__init__(message)
+        super(SilverbackException, self).__init__(message)

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Sequence
 
 from ape.exceptions import ApeException
 
@@ -28,6 +28,20 @@ class NoWebsocketAvailableError(Exception):
 
 class SilverbackException(ApeException):
     """Base Exception for any Silverback runtime faults."""
+
+
+# TODO: `ExceptionGroup` added in Python 3.11
+class StartupFailure(SilverbackException):
+    def __init__(self, *exceptions: Sequence[Exception]):
+        if error_str := "\n".join(str(e) for e in exceptions):
+            super().__init__(f"Startup failure(s):\n{error_str}")
+        else:
+            super().__init__("Startup failure(s) detected. See logs for details.")
+
+
+class NoTasksAvailableError(SilverbackException):
+    def __init__(self):
+        super().__init__("No tasks to execute")
 
 
 class Halt(SilverbackException):

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Dict
 
 from ape.logging import logger
 from ape.types import ContractLog
@@ -26,7 +26,7 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
     def pre_send(self, message: TaskiqMessage) -> TaskiqMessage:
         # TODO: Necessary because bytes/HexBytes doesn't encode/deocde well for some reason
         def fix_dict(data: dict, recurse_count: int = 0) -> dict:
-            fixed_data: dict[str, Any] = {}
+            fixed_data: Dict[str, Any] = {}
             for name, value in data.items():
                 if isinstance(value, bytes):
                     fixed_data[name] = to_hex(value)

--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -52,7 +52,7 @@ class HandlerResult(TaskiqResult):
         )
 
 
-class BasePersistentStore(ABC):
+class BaseRecorder(ABC):
     @abstractmethod
     async def init(self):
         """Handle any async initialization from Silverback settings (e.g. migrations)."""
@@ -83,16 +83,16 @@ class BasePersistentStore(ABC):
         ...
 
 
-class SQLitePersistentStore(BasePersistentStore):
+class SQLiteRecorder(BaseRecorder):
     """
-    SQLite implementation of BasePersistentStore used to store application state and handler
+    SQLite implementation of BaseRecorder used to store application state and handler
     result data.
 
     Usage:
 
-    To use SQLite persistent store, you must configure the following env vars:
+    To use SQLite recorder, you must configure the following env vars:
 
-    - `PERSISTENCE_CLASS`: `silverback.persistence.SQLitePersistentStore`
+    - `RECORDER_CLASS`: `silverback.recorder.SQLiteRecorder`
     - `SQLITE_PATH` (optional): A system file path or if blank it will be stored in-memory.
     """
 

--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Iterator, Optional
+from typing import Any, Dict, Iterator, Optional
 
 from ape.logging import get_logger
 from pydantic import BaseModel, Field
@@ -36,10 +36,10 @@ class TaskResult(BaseModel):
     block_number: Optional[int] = None
 
     # Custom user metrics here
-    metrics: dict[str, Datapoint] = {}
+    metrics: Dict[str, Datapoint] = {}
 
     @classmethod
-    def _extract_custom_metrics(cls, result: Any, task_name: str) -> dict[str, Datapoint]:
+    def _extract_custom_metrics(cls, result: Any, task_name: str) -> Dict[str, Datapoint]:
         if isinstance(result, Datapoint):  # type: ignore[arg-type,misc]
             return {"result": result}
 

--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -183,7 +183,7 @@ class JSONLineRecorder(BaseRecorder):
             writer.write("\n")
 
 
-def get_metrics(session: Path | str, task_name: str) -> Iterator[dict]:
+def get_metrics(session: Path, task_name: str) -> Iterator[dict]:
     with open(session, "r") as file:
         for line in file:
             if (

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -36,10 +36,11 @@ class BaseRunner(ABC):
             self.exceptions += 1
 
         else:
+            # NOTE: Reset exception counter
             self.exceptions = 0
 
         if self.exceptions > self.max_exceptions:
-            raise Halt()
+            raise Halt() from result.error
 
     async def _checkpoint(
         self, last_block_seen: int = 0, last_block_processed: int = 0

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -1,73 +1,88 @@
 import asyncio
 from abc import ABC, abstractmethod
-from typing import Optional, Tuple
+from typing import Optional
 
 from ape import chain
 from ape.contracts import ContractEvent, ContractInstance
 from ape.logging import logger
 from ape.utils import ManagerAccessMixin
 from ape_ethereum.ecosystem import keccak
-from taskiq import AsyncTaskiqDecoratedTask, TaskiqResult
+from taskiq import AsyncTaskiqDecoratedTask, AsyncTaskiqTask
 
 from .application import SilverbackApp
 from .exceptions import Halt, NoWebsocketAvailableError
-from .recorder import BaseRecorder
-from .settings import Settings
+from .recorder import BaseRecorder, TaskResult
 from .subscriptions import SubscriptionType, Web3SubscriptionsManager
-from .types import SilverbackID, SilverbackStartupState, TaskType
+from .types import AppState, SilverbackID, TaskType
 from .utils import async_wrap_iter, hexbytes_dict
-
-settings = Settings()
 
 
 class BaseRunner(ABC):
-    def __init__(self, app: SilverbackApp, *args, max_exceptions: int = 3, **kwargs):
+    def __init__(
+        self,
+        app: SilverbackApp,
+        *args,
+        max_exceptions: int = 3,
+        recorder: Optional[BaseRecorder] = None,
+        **kwargs,
+    ):
         self.app = app
+        self.recorder = recorder
 
         self.max_exceptions = max_exceptions
         self.exceptions = 0
-        self.last_block_seen = 0
-        self.last_block_processed = 0
-        self.recorder: Optional[BaseRecorder] = None
-        self.ident = SilverbackID.from_settings(settings)
 
-    def _handle_result(self, result: TaskiqResult):
-        if result.is_err:
-            self.exceptions += 1
+        ecosystem_name, network_name = app.network_choice.split(":")
+        self.identifier = SilverbackID(
+            name=app.name,
+            ecosystem=ecosystem_name,
+            network=network_name,
+        )
 
-        else:
+        logger.info(f"Using {self.__class__.__name__}: max_exceptions={self.max_exceptions}")
+
+    async def _handle_task(self, task: AsyncTaskiqTask):
+        result = await task.wait_result()
+
+        if self.recorder:
+            await self.recorder.add_result(TaskResult.from_taskiq(result))
+
+        if not result.is_err:
             # NOTE: Reset exception counter
             self.exceptions = 0
+            return
 
-        if self.exceptions > self.max_exceptions:
-            raise Halt() from result.error
+        self.exceptions += 1
+
+        if self.exceptions > self.max_exceptions or isinstance(result.error, Halt):
+            result.raise_for_error()
 
     async def _checkpoint(
-        self, last_block_seen: int = 0, last_block_processed: int = 0
-    ) -> Tuple[int, int]:
+        self,
+        last_block_seen: Optional[int] = None,
+        last_block_processed: Optional[int] = None,
+    ):
         """Set latest checkpoint block number"""
-        if (
-            last_block_seen > self.last_block_seen
-            or last_block_processed > self.last_block_processed
-        ):
-            logger.debug(
-                (
-                    f"Checkpoint block [seen={self.last_block_seen}, "
-                    f"procssed={self.last_block_processed}]"
-                )
+        assert self.app.state, f"{self.__class__.__name__}.run() not triggered."
+
+        logger.debug(
+            (
+                f"Checkpoint block [seen={self.app.state.last_block_seen}, "
+                f"procssed={self.app.state.last_block_processed}]"
             )
-            self.last_block_seen = max(last_block_seen, self.last_block_seen)
-            self.last_block_processed = max(last_block_processed, self.last_block_processed)
+        )
 
-            if self.recorder:
-                try:
-                    await self.recorder.set_state(
-                        self.ident, self.last_block_seen, self.last_block_processed
-                    )
-                except Exception as err:
-                    logger.error(f"Error settings state: {err}")
+        if last_block_seen:
+            self.app.state.last_block_seen = last_block_seen
+        if last_block_processed:
+            self.app.state.last_block_processed = last_block_processed
 
-        return self.last_block_seen, self.last_block_processed
+        if self.recorder:
+            try:
+                await self.recorder.set_state(self.app.state)
+
+            except Exception as err:
+                logger.error(f"Error setting state: {err}")
 
     @abstractmethod
     async def _block_task(self, block_handler: AsyncTaskiqDecoratedTask):
@@ -93,14 +108,14 @@ class BaseRunner(ABC):
         Raises:
             :class:`~silverback.exceptions.Halt`: If there are no configured tasks to execute.
         """
-        self.recorder = settings.get_recorder()
+        # Initialize recorder (if available) and fetch state if app has been run previously
+        if self.recorder and (startup_state := (await self.recorder.init(app_id=self.identifier))):
+            self.app.state = startup_state
 
-        if self.recorder:
-            boot_state = await self.recorder.get_state(self.ident)
-            if boot_state:
-                self.last_block_seen = boot_state.last_block_seen
-                self.last_block_processed = boot_state.last_block_processed
+        else:  # use empty state
+            self.app.state = AppState(last_block_seen=-1, last_block_processed=-1)
 
+        # Initialize broker (run worker startup events)
         await self.app.broker.startup()
 
         # Execute Silverback startup task before we init the rest
@@ -144,7 +159,6 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
 
     def __init__(self, app: SilverbackApp, *args, **kwargs):
         super().__init__(app, *args, **kwargs)
-        logger.info(f"Using {self.__class__.__name__}: max_exceptions={self.max_exceptions}")
 
         # Check for websocket support
         if not (ws_uri := app.chain_manager.provider.ws_uri):
@@ -159,16 +173,9 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
         async for raw_block in self.subscriptions.get_subscription_data(sub_id):
             block = self.provider.network.ecosystem.decode_block(hexbytes_dict(raw_block))
 
-            if block.number is not None:
-                await self._checkpoint(last_block_seen=block.number)
-
-            block_task = await block_handler.kiq(raw_block)
-            result = await block_task.wait_result()
-
-            self._handle_result(result)
-
-            if block.number is not None:
-                await self._checkpoint(last_block_processed=block.number)
+            await self._checkpoint(last_block_seen=block.number)
+            await self._handle_task(await block_handler.kiq(raw_block))
+            await self._checkpoint(last_block_processed=block.number)
 
     async def _event_task(
         self, contract_event: ContractEvent, event_handler: AsyncTaskiqDecoratedTask
@@ -182,7 +189,9 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
             address=contract_event.contract.address,
             topics=["0x" + keccak(text=contract_event.abi.selector).hex()],
         )
-        logger.debug(f"Handling '{contract_event.name}' events via {sub_id}")
+        logger.debug(
+            f"Handling '{contract_event.contract.address}:{contract_event.name}' logs via {sub_id}"
+        )
 
         async for raw_event in self.subscriptions.get_subscription_data(sub_id):
             event = next(  # NOTE: `next` is okay since it only has one item
@@ -192,15 +201,9 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
                 )
             )
 
-            if event.block_number is not None:
-                await self._checkpoint(last_block_seen=event.block_number)
-
-            event_task = await event_handler.kiq(event)
-            result = await event_task.wait_result()
-            self._handle_result(result)
-
-            if event.block_number is not None:
-                await self._checkpoint(last_block_processed=event.block_number)
+            await self._checkpoint(last_block_seen=event.block_number)
+            await self._handle_task(await event_handler.kiq(event))
+            await self._checkpoint(last_block_processed=event.block_number)
 
     async def run(self):
         async with Web3SubscriptionsManager(self.ws_uri) as subscriptions:
@@ -235,15 +238,9 @@ class PollingRunner(BaseRunner):
         async for block in async_wrap_iter(
             chain.blocks.poll_blocks(start_block=start_block, new_block_timeout=new_block_timeout)
         ):
-            if block.number is not None:
-                await self._checkpoint(last_block_seen=block.number)
-
-            block_task = await block_handler.kiq(block)
-            result = await block_task.wait_result()
-            self._handle_result(result)
-
-            if block.number is not None:
-                await self._checkpoint(last_block_processed=block.number)
+            await self._checkpoint(last_block_seen=block.number)
+            await self._handle_task(await block_handler.kiq(block))
+            await self._checkpoint(last_block_processed=block.number)
 
     async def _event_task(
         self, contract_event: ContractEvent, event_handler: AsyncTaskiqDecoratedTask
@@ -265,12 +262,6 @@ class PollingRunner(BaseRunner):
         async for event in async_wrap_iter(
             contract_event.poll_logs(start_block=start_block, new_block_timeout=new_block_timeout)
         ):
-            if event.block_number is not None:
-                await self._checkpoint(last_block_seen=event.block_number)
-
-            event_task = await event_handler.kiq(event)
-            result = await event_task.wait_result()
-            self._handle_result(result)
-
-            if event.block_number is not None:
-                await self._checkpoint(last_block_processed=event.block_number)
+            await self._checkpoint(last_block_seen=event.block_number)
+            await self._handle_task(await event_handler.kiq(event))
+            await self._checkpoint(last_block_processed=event.block_number)

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -10,7 +10,7 @@ from ape_ethereum.ecosystem import keccak
 from taskiq import AsyncTaskiqDecoratedTask, AsyncTaskiqTask
 
 from .application import SilverbackApp
-from .exceptions import Halt, NoWebsocketAvailableError
+from .exceptions import Halt, NoTasksAvailableError, NoWebsocketAvailableError, StartupFailure
 from .recorder import BaseRecorder, TaskResult
 from .subscriptions import SubscriptionType, Web3SubscriptionsManager
 from .types import AppState, SilverbackID, TaskType
@@ -106,7 +106,10 @@ class BaseRunner(ABC):
         and process them by kicking events over to the configured broker.
 
         Raises:
-            :class:`~silverback.exceptions.Halt`: If there are no configured tasks to execute.
+            :class:`~silverback.exceptions.StartupFailure`:
+                If there was an exception during startup.
+            :class:`~silverback.exceptions.NoTasksAvailableError`:
+                If there are no configured tasks to execute.
         """
         # Initialize recorder (if available) and fetch state if app has been run previously
         if self.recorder and (startup_state := (await self.recorder.init(app_id=self.identifier))):
@@ -119,35 +122,57 @@ class BaseRunner(ABC):
         await self.app.broker.startup()
 
         # Execute Silverback startup task before we init the rest
-        for startup_task in self.app.tasks[TaskType.STARTUP]:
-            task = await startup_task.handler.kiq(
-                SilverbackStartupState(
-                    last_block_seen=self.last_block_seen,
-                    last_block_processed=self.last_block_processed,
-                )
+        if startup_tasks := await asyncio.gather(
+            *(task_def.handler.kiq() for task_def in self.app.tasks[TaskType.STARTUP])
+        ):
+            results = await asyncio.gather(
+                *(startup_task.wait_result() for startup_task in startup_tasks)
             )
-            result = await task.wait_result()
-            self._handle_result(result)
 
-        tasks = []
-        for task in self.app.tasks[TaskType.NEW_BLOCKS]:
-            tasks.append(self._block_task(task.handler))
+            if any(result.is_err for result in results):
+                # NOTE: Abort before even starting to run
+                raise StartupFailure(*(result.error for result in results if result.is_err))
+            # NOTE: No need to handle results otherwise
 
-        for task in self.app.tasks[TaskType.EVENT_LOG]:
-            tasks.append(self._event_task(task.container, task.handler))
+        # Create our long-running event listeners
+        # NOTE: Any propagated failure in here should be handled such that shutdown tasks also run
+        # TODO: `asyncio.TaskGroup` added in Python 3.11
+        listener_tasks = (
+            *(
+                asyncio.create_task(self._block_task(task_def.handler))
+                for task_def in self.app.tasks[TaskType.NEW_BLOCKS]
+            ),
+            *(
+                asyncio.create_task(self._event_task(task_def.container, task_def.handler))
+                for task_def in self.app.tasks[TaskType.EVENT_LOG]
+            ),
+        )
 
-        if len(tasks) == 0:
-            raise Halt("No tasks to execute")
+        # NOTE: Safe to do this because no tasks have been scheduled to run yet
+        if len(listener_tasks) == 0:
+            raise NoTasksAvailableError()
 
-        try:
-            await asyncio.gather(*tasks)
-        except Exception as e:
-            logger.error(f"Fatal error detected, shutting down: '{e}'")
+        # Run until one task bubbles up an exception that should stop execution
+        tasks_with_errors, tasks_running = await asyncio.wait(
+            listener_tasks, return_when=asyncio.FIRST_EXCEPTION
+        )
+        if runtime_errors := "\n".join(str(task.exception()) for task in tasks_with_errors):
+            # NOTE: In case we are somehow not displaying the error correctly with task status
+            logger.debug(f"Runtime error(s) detected, shutting down:\n{runtime_errors}")
 
-        # Execute Silverback shutdown task before shutting down the broker
-        for shutdown_task in self.app.tasks[TaskType.SHUTDOWN]:
-            task = await shutdown_task.handler.kiq()
-            result = self._handle_result(await task.wait_result())
+        # Cancel any still running
+        (task.cancel() for task in tasks_running)
+        # NOTE: All listener tasks are shut down now
+
+        # Execute Silverback shutdown task(s) before shutting down the broker and app
+        if shutdown_tasks := await asyncio.gather(
+            *(task_def.handler.kiq() for task_def in self.app.tasks[TaskType.SHUTDOWN])
+        ):
+            asyncio.gather(*(shutdown_task.is_ready() for shutdown_task in shutdown_tasks))
+            if any(result.is_err for result in results):
+                errors_str = "\n".join(str(result.error) for result in results if result.is_err)
+                logger.error(f"Errors while shutting down:\n{errors_str}")
+            # NOTE: No need to handle results otherwise
 
         await self.app.broker.shutdown()
 

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings, ManagerAccessMixin):
     """
 
     # A unique identifier for this silverback instance
-    INSTANCE: str = "default"
+    APP_NAME: str = "bot"
 
     BROKER_CLASS: str = "taskiq:InMemoryBroker"
     BROKER_URI: str = ""

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -7,7 +7,7 @@ from taskiq import AsyncBroker, InMemoryBroker, PrometheusMiddleware, TaskiqMidd
 
 from ._importer import import_from_string
 from .middlewares import SilverbackMiddleware
-from .persistence import BasePersistentStore
+from .recorder import BaseRecorder
 
 
 class Settings(BaseSettings, ManagerAccessMixin):
@@ -35,8 +35,8 @@ class Settings(BaseSettings, ManagerAccessMixin):
     NEW_BLOCK_TIMEOUT: Optional[int] = None
     START_BLOCK: Optional[int] = None
 
-    # Used for persistent store
-    PERSISTENCE_CLASS: Optional[str] = None
+    # Used for recorder
+    RECORDER_CLASS: Optional[str] = None
 
     model_config = SettingsConfigDict(env_prefix="SILVERBACK_", case_sensitive=True)
 
@@ -68,12 +68,12 @@ class Settings(BaseSettings, ManagerAccessMixin):
     def get_network_choice(self) -> str:
         return self.NETWORK_CHOICE or self.network_manager.network.choice
 
-    def get_persistent_store(self) -> Optional[BasePersistentStore]:
-        if not self.PERSISTENCE_CLASS:
+    def get_recorder(self) -> Optional[BaseRecorder]:
+        if not self.RECORDER_CLASS:
             return None
 
-        persistence_class = import_from_string(self.PERSISTENCE_CLASS)
-        return persistence_class()
+        recorder_class = import_from_string(self.RECORDER_CLASS)
+        return recorder_class()
 
     def get_provider_context(self) -> ProviderContextManager:
         # NOTE: Bit of a workaround for adhoc connections:

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,11 +1,12 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
-from typing import Annotated, Literal, Union
+from typing import Literal, Union
 
 from pydantic import BaseModel, Field
 from pydantic.functional_serializers import PlainSerializer
 from taskiq import Context, TaskiqDepends, TaskiqState
+from typing_extensions import Annotated  # Introduced 3.9
 
 
 class TaskType(str, Enum):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -20,7 +20,7 @@ class ISilverbackSettings(Protocol):
     a type reference."""
 
     INSTANCE: str
-    PERSISTENCE_CLASS: Optional[str]
+    RECORDER_CLASS: Optional[str]
 
     def get_network_choice(self) -> str:
         ...

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,10 +1,27 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
-from typing import Literal, Optional, Protocol, get_args
+from typing import Annotated, Literal, Optional, Protocol
 
 from pydantic import BaseModel, Field
+from pydantic.functional_serializers import PlainSerializer
+from taskiq import Context, TaskiqDepends, TaskiqState
 from typing_extensions import Self  # Introduced 3.11
+
+
+def iso_format(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+UTCTimestamp = Annotated[
+    datetime,
+    # TODO: Bug in TaskIQ can't serialize `datetime`
+    PlainSerializer(iso_format, return_type=str),
+]
 
 
 class TaskType(str, Enum):
@@ -42,24 +59,24 @@ class SilverbackStartupState(BaseModel):
     last_block_processed: int
 
 
-class BaseDatapoint(BaseModel):
+
+
+
+
+class _BaseDatapoint(BaseModel):
     type: str  # discriminator
 
-    # NOTE: default value ensures we don't have to set this manually
-    time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
 
-
+# NOTE: only these types of data are implicitly converted e.g. `{"something": 1, "else": 0.001}`
 ScalarType = bool | int | float | Decimal
-scalar_types = get_args(ScalarType)
 
 
-class ScalarDatapoint(BaseDatapoint):
+class ScalarDatapoint(_BaseDatapoint):
     type: Literal["scalar"] = "scalar"
-
-    # NOTE: app-supported scalar value types:
     data: ScalarType
 
 
-# This is what a Silverback app task must return to integrate properly with our data acq system
-Metrics = dict[str, BaseDatapoint]
-# Otherwise, log a warning and ignore any unconverted return value(s)
+# NOTE: Other datapoint types must be explicitly used
+
+# TODO: Other datapoint types added to union here...
+Datapoint = ScalarDatapoint

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Union
 
 from pydantic import BaseModel, Field
 from pydantic.functional_serializers import PlainSerializer
@@ -63,7 +63,7 @@ class _BaseDatapoint(BaseModel):
 
 
 # NOTE: only these types of data are implicitly converted e.g. `{"something": 1, "else": 0.001}`
-ScalarType = bool | int | float | Decimal
+ScalarType = Union[bool, int, float, Decimal]
 
 
 class ScalarDatapoint(_BaseDatapoint):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,12 +1,27 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
-from typing import Annotated, Literal, Optional, Protocol
+from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
 from pydantic.functional_serializers import PlainSerializer
 from taskiq import Context, TaskiqDepends, TaskiqState
-from typing_extensions import Self  # Introduced 3.11
+
+
+class TaskType(str, Enum):
+    STARTUP = "silverback_startup"  # TODO: Shorten in 0.4.0
+    NEW_BLOCKS = "block"
+    EVENT_LOG = "event"
+    SHUTDOWN = "silverback_shutdown"  # TODO: Shorten in 0.4.0
+
+    def __str__(self) -> str:
+        return self.value
+
+
+class SilverbackID(BaseModel):
+    name: str
+    ecosystem: str
+    network: str
 
 
 def iso_format(dt: datetime) -> str:
@@ -24,43 +39,23 @@ UTCTimestamp = Annotated[
 ]
 
 
-class TaskType(str, Enum):
-    STARTUP = "silverback_startup"  # TODO: Shorten in 0.4.0
-    NEW_BLOCKS = "block"
-    EVENT_LOG = "event"
-    SHUTDOWN = "silverback_shutdown"  # TODO: Shorten in 0.4.0
-
-    def __str__(self) -> str:
-        return self.value
-
-
-class ISilverbackSettings(Protocol):
-    """Loose approximation of silverback.settings.Settings.  If you can, use the class as
-    a type reference."""
-
-    INSTANCE: str
-    RECORDER_CLASS: Optional[str]
-
-    def get_network_choice(self) -> str:
-        ...
-
-
-class SilverbackID(BaseModel):
-    identifier: str
-    network_choice: str
-
-    @classmethod
-    def from_settings(cls, settings_: ISilverbackSettings) -> Self:
-        return cls(identifier=settings_.INSTANCE, network_choice=settings_.get_network_choice())
-
-
-class SilverbackStartupState(BaseModel):
+class AppState(BaseModel):
+    # Last block number seen by runner
     last_block_seen: int
+
+    # Last block number processed by a worker
     last_block_processed: int
 
+    # Last time the state was updated
+    # NOTE: intended to use default when creating a model with this type
+    last_updated: UTCTimestamp = Field(default_factory=utc_now)
 
 
+def get_worker_state(context: Annotated[Context, TaskiqDepends()]) -> TaskiqState:
+    return context.state
 
+
+WorkerState = Annotated[TaskiqState, TaskiqDepends(get_worker_state)]
 
 
 class _BaseDatapoint(BaseModel):

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,7 +1,9 @@
+from datetime import datetime, timezone
+from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
-from typing import Optional, Protocol
+from typing import Literal, Optional, Protocol, get_args
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from typing_extensions import Self  # Introduced 3.11
 
 
@@ -38,3 +40,26 @@ class SilverbackID(BaseModel):
 class SilverbackStartupState(BaseModel):
     last_block_seen: int
     last_block_processed: int
+
+
+class BaseDatapoint(BaseModel):
+    type: str  # discriminator
+
+    # NOTE: default value ensures we don't have to set this manually
+    time: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+
+
+ScalarType = bool | int | float | Decimal
+scalar_types = get_args(ScalarType)
+
+
+class ScalarDatapoint(BaseDatapoint):
+    type: Literal["scalar"] = "scalar"
+
+    # NOTE: app-supported scalar value types:
+    data: ScalarType
+
+
+# This is what a Silverback app task must return to integrate properly with our data acq system
+Metrics = dict[str, BaseDatapoint]
+# Otherwise, log a warning and ignore any unconverted return value(s)

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -63,8 +63,10 @@ class _BaseDatapoint(BaseModel):
     type: str  # discriminator
 
 
+# NOTE: Maximum supported parquet integer type: https://parquet.apache.org/docs/file-format/types
+Int96 = Annotated[int, Field(ge=-(2**95), le=2**95 - 1)]
 # NOTE: only these types of data are implicitly converted e.g. `{"something": 1, "else": 0.001}`
-ScalarType = Union[bool, int, float, Decimal]
+ScalarType = Union[bool, Int96, float, Decimal]
 
 
 class ScalarDatapoint(_BaseDatapoint):


### PR DESCRIPTION
### What I did

Adds a constraint to integer scalar types to make sure they fit inside of parquet files (up to 63 digit integers supported, or >1e45 units of 1e18 decimal tokens)

depends: #69, #64

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
