### PR TITLE
fix(devops): do not use macos-latest until there's a setup-python fix

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,7 +62,9 @@ jobs:
 
         strategy:
             matrix:
-                os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
+                # TODO: Replace with macos-latest when works again.
+                #   https://github.com/actions/setup-python/issues/808
+                os: [ubuntu-latest, macos-12]   # eventually add `windows-latest`
                 python-version: [3.8, 3.9, "3.10", "3.11"]
 
         steps:


### PR DESCRIPTION
### What I did

Pinned runner to macos-12 until setup-python is fixed.

Ref: https://github.com/ApeWorX/ape/pull/2020

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
