### PR TITLE
chore: update docker container to python 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #---------------------------------------------------------------------------------------------
 
 # Build with builder image to reduce image size
-FROM python:3.10 as builder
+FROM python:3.11 as builder
 USER root
 WORKDIR /wheels
 COPY . .


### PR DESCRIPTION
### What I did

Updates the `Dockerfile` python version to 3.11 because features.

Depends on: https://github.com/ApeWorX/ape/pull/2042

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
