### PR TITLE
chore: use ape latest docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install --upgrade pip && pip install wheel
 RUN pip wheel . --wheel-dir=/wheels
 
 # Install from wheels
-FROM apeworx/ape:stable
+FROM apeworx/ape:latest
 USER root
 COPY --from=builder /wheels /wheels
 RUN pip install --upgrade pip \


### PR DESCRIPTION
### What I did

Would like to set latest temporarily.  Will change it back after next ape release.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
