### PR TITLE
fix: error checking type for "subscripted generics"

### DIFF
--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any, Iterator, get_args
 
 from ape.logging import get_logger
 from pydantic import BaseModel, Field
@@ -43,7 +43,7 @@ class TaskResult(BaseModel):
         if isinstance(result, Datapoint):  # type: ignore[arg-type,misc]
             return {"result": result}
 
-        elif isinstance(result, ScalarType):
+        elif isinstance(result, get_args(ScalarType)):
             if isinstance(result, int) and not (INT96_RANGE[0] <= result <= INT96_RANGE[1]):
                 logger.warn("Result integer is out of range suitable for parquet. Ignoring.")
             else:

--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -8,6 +8,7 @@ from taskiq import TaskiqResult
 from typing_extensions import Self  # Introduced 3.11
 
 from .types import (
+    INT96_RANGE,
     Datapoint,
     ScalarDatapoint,
     ScalarType,
@@ -42,8 +43,11 @@ class TaskResult(BaseModel):
         if isinstance(result, Datapoint):  # type: ignore[arg-type,misc]
             return {"result": result}
 
-        elif isinstance(result, ScalarType):  # type: ignore[arg-type,misc]
-            return {"result": ScalarDatapoint(data=result)}
+        elif isinstance(result, ScalarType):
+            if isinstance(result, int) and not (INT96_RANGE[0] <= result <= INT96_RANGE[1]):
+                logger.warn("Result integer is out of range suitable for parquet. Ignoring.")
+            else:
+                return {"result": ScalarDatapoint(data=result)}
 
         elif result is None:
             return {}

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
-from typing import Any, Literal
+from typing import Literal
 
 from ape.logging import get_logger
 from pydantic import BaseModel, Field, RootModel, ValidationError, model_validator
 from pydantic.functional_serializers import PlainSerializer
-from typing_extensions import Annotated, get_args
+from typing_extensions import Annotated
 
 logger = get_logger(__name__)
 

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -44,14 +44,17 @@ class _BaseDatapoint(BaseModel):
 
 
 # NOTE: Maximum supported parquet integer type: https://parquet.apache.org/docs/file-format/types
-Int96 = Annotated[int, Field(ge=-(2**95), le=2**95 - 1)]
+INT96_RANGE = (-(2**95), 2**95 - 1)
+Int96 = Annotated[int, Field(ge=INT96_RANGE[0], le=INT96_RANGE[1])]
 # NOTE: only these types of data are implicitly converted e.g. `{"something": 1, "else": 0.001}`
-ScalarType = bool | Int96 | float | Decimal
+PydanticScalarType = bool | Int96 | float | Decimal
+# NOTE: Use this for isinstance() comparisons and the like
+ScalarType = bool | int | float | Decimal
 
 
 class ScalarDatapoint(_BaseDatapoint):
     type: Literal["scalar"] = "scalar"
-    data: ScalarType
+    data: PydanticScalarType
 
 
 # NOTE: Other datapoint types must be explicitly used

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -1,11 +1,11 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 from enum import Enum  # NOTE: `enum.StrEnum` only in Python 3.11+
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 from pydantic.functional_serializers import PlainSerializer
-from typing_extensions import Annotated
+from typing_extensions import Annotated, get_args
 
 
 class TaskType(str, Enum):
@@ -47,14 +47,17 @@ class _BaseDatapoint(BaseModel):
 INT96_RANGE = (-(2**95), 2**95 - 1)
 Int96 = Annotated[int, Field(ge=INT96_RANGE[0], le=INT96_RANGE[1])]
 # NOTE: only these types of data are implicitly converted e.g. `{"something": 1, "else": 0.001}`
-PydanticScalarType = bool | Int96 | float | Decimal
-# NOTE: Use this for isinstance() comparisons and the like
-ScalarType = bool | int | float | Decimal
+ScalarType = bool | Int96 | float | Decimal
+SCALAR_TYPES = tuple(t.__origin__ if hasattr(t, "__origin__") else t for t in get_args(ScalarType))
+
+
+def is_scalar_type(val: Any) -> bool:
+    return isinstance(val, SCALAR_TYPES)
 
 
 class ScalarDatapoint(_BaseDatapoint):
     type: Literal["scalar"] = "scalar"
-    data: PydanticScalarType
+    data: ScalarType
 
 
 # NOTE: Other datapoint types must be explicitly used

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -88,3 +88,19 @@ class Datapoints(RootModel):
             )
 
         return datapoints
+
+    # Add dict methods
+    def get(self, key: str, default: Datapoint | None = None) -> Datapoint | None:
+        if key in self:
+            return self[key]
+
+        return default
+
+    def __iter__(self):
+        return iter(self.root)
+
+    def __getitem__(self, item):
+        return self.root[item]
+
+    def items(self):
+        return self.root.items()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,38 @@
+from decimal import Decimal
+
+import pytest
+
+from silverback.types import Datapoints
+
+
+@pytest.mark.parametrize(
+    "raw_return,expected",
+    [
+        # String datapoints don't parse (empty datapoints)
+        ({"a": "b"}, {}),
+        # ints parse
+        ({"a": 1}, {"a": {"type": "scalar", "data": 1}}),
+        # max INT96 value
+        (
+            {"a": 2**96 - 1},
+            {"a": {"type": "scalar", "data": 79228162514264337593543950335}},
+        ),
+        # int over INT96 max parses as Decimal
+        (
+            {"a": 2**96},
+            {"a": {"type": "scalar", "data": Decimal("79228162514264337593543950336")}},
+        ),
+        # Decimal parses as Decimal
+        (
+            {"a": Decimal("1e12")},
+            {"a": {"type": "scalar", "data": Decimal("1000000000000")}},
+        ),
+        # float parses as float
+        (
+            {"a": 1e12},
+            {"a": {"type": "scalar", "data": 1000000000000.0}},
+        ),
+    ],
+)
+def test_datapoint_parsing(raw_return, expected):
+    assert Datapoints(root=raw_return).model_dump() == expected


### PR DESCRIPTION
### What I did

Fixes the error:

```
[...snip...]
  File "/home/mike/.venvs/silverback-cluster/lib/python3.11/site-packages/silverback/recorder.py", line 91, in from_taskiq
    metrics=cls._extract_custom_metrics(result.return_value, task_name),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mike/.venvs/silverback-cluster/lib/python3.11/site-packages/silverback/recorder.py", line 45, in _extract_custom_metrics
    elif isinstance(result, ScalarType):  # type: ignore[arg-type,misc]
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/typing.py", line 1689, in __instancecheck__
    return self.__subclasscheck__(type(obj))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/typing.py", line 1693, in __subclasscheck__
    if issubclass(cls, arg):
       ^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/typing.py", line 1315, in __subclasscheck__
    raise TypeError("Subscripted generics cannot be used with"
TypeError: Subscripted generics cannot be used with class and instance checks
```


### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
