### PR TITLE
feat!: add `app.state`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install --upgrade pip \
     && pip install \
     --no-cache-dir --find-links=/wheels \
     'taskiq-sqs>=0.0.11' \
-    'taskiq-redis>=1.0.2,<2'
+    'taskiq-redis>=1.0.2,<2' \
     silverback
 
 USER harambe

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,13 @@ RUN pip wheel . --wheel-dir=/wheels
 # Install from wheels
 FROM ghcr.io/apeworx/ape:${BASE_APE_IMAGE_TAG:-latest}
 USER root
-COPY --from=builder /wheels /wheels
+COPY --from=builder /wheels/*.whl /wheels
 RUN pip install --upgrade pip \
-    && pip install silverback \
+    && pip install \
+    --no-cache-dir --no-index --find-links=/wheels \
     'taskiq-sqs>=0.0.11' \
-    --no-cache-dir --find-links=/wheels
+    silverback
+
 USER harambe
 
 ENTRYPOINT ["silverback"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN pip install --upgrade pip \
     && pip install \
     --no-cache-dir --find-links=/wheels \
     'taskiq-sqs>=0.0.11' \
+    'taskiq-redis>=1.0.2,<2'
     silverback
 
 USER harambe

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ USER root
 COPY --from=builder /wheels/*.whl /wheels
 RUN pip install --upgrade pip \
     && pip install \
-    --no-cache-dir --no-index --find-links=/wheels \
+    --no-cache-dir --find-links=/wheels \
     'taskiq-sqs>=0.0.11' \
     silverback
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Quick Start
 
 Silverback lets you create and deploy your own Python bots that respond to on-chain events.
-The Silverback library leverages the [Ape](https://docs.apeworx.io/ape/stable/userguides/quickstart) development framework as well as it's ecosystem of plugins and packages to enable you to develop simple-yet-sophisticated automated applications that can listen and respond to live chain data.
+The Silverback library leverages the [Ape](https://docs.apeworx.io/ape/stable/userguides/quickstart) development framework as well as it's ecosystem of plugins and packages to enable you to develop simple-yet-sophisticated automated bots that can listen and respond to live chain data.
 
-Silverback applications are excellent for use cases that involve continuously monitoring and responding to on-chain events, such as newly confirmed blocks or contract event logs.
+Silverback bots are excellent for use cases that involve continuously monitoring and responding to on-chain events, such as newly confirmed blocks or contract event logs.
 
-Some examples of these types of applications:
+Some examples of these types of bots:
 
 - Monitoring new pool creations, and depositing liquidity
 - Measuring trading activity of popular pools
@@ -13,7 +13,7 @@ Some examples of these types of applications:
 
 ## Documentation
 
-Please read the [development userguide](https://docs.apeworx.io/silverback/stable/userguides/development.html) for more information on how to develop an application.
+Please read the [development userguide](https://docs.apeworx.io/silverback/stable/userguides/development.html) for more information on how to develop a bot.
 
 ## Dependencies
 
@@ -72,11 +72,11 @@ Silverback will automatically register files in this folder as separate bots tha
 
 ```{note}
 It is also suggested that you treat this as a scripts folder, and do not include an __init__.py
-If you have a complicated project, follow the previous example to ensure you run the application correctly.
+If you have a complicated project, follow the previous example to ensure you run the bot correctly.
 ```
 
 ```{note}
-A final suggestion would be to name your `SilverbackApp` object `bot`. Silverback automatically searches 
+A final suggestion would be to name your `SilverbackBot` object `bot`. Silverback automatically searches 
 for this object name when running. If you do not do so, once again, ensure you replace `example` with 
 `example:<name-of-object>` the previous example.
 ```
@@ -139,7 +139,7 @@ Traceback (most recent call last):
 ape_alchemy.exceptions.MissingProjectKeyError: Must set one of $WEB3_ALCHEMY_PROJECT_ID, $WEB3_ALCHEMY_API_KEY, $WEB3_ETHEREUM_MAINNET_ALCHEMY_PROJECT_ID, $WEB3_ETHEREUM_MAINNET_ALCHEMY_API_KEY.
 ```
 
-Go to [Alchemy](https://alchemy.com), create an account, then create an application in their dashboard, and copy the API Key.
+Go to [Alchemy](https://alchemy.com), create an account, then create an bot in their dashboard, and copy the API Key.
 
 Another requirement for the command from `Docker Usage` to run the given example is that it uses [ape-tokens](https://github.com/ApeWorX/ape-tokens) plugin to look up token interfaces by symbol.
 In order for this to work, you should have installed and configured that plugin using a token list that includes both YFI and USDC on Ethereum mainnet.

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -218,7 +218,7 @@ You can use `bot.state` to store any python variable type, however note that the
 ```
 
 ```{note}
-Bot startup and bot runtime events (e.g. block or event container) are handled distinctly and can be trusted not to execute at the same time.
+Bot startup and bot runtime event triggers (e.g. block or event container) are handled distinctly and can be trusted not to execute at the same time.
 ```
 
 ### Signing Transactions

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -208,6 +208,7 @@ def update_table(log):
 @app.on_(chain.blocks)
 def use_table(blk):
     if app.state.table[...].mean() > app.state.table[...].sum():
+        # Trigger your app to send a transaction from `app.signer`
         contract.myMethod(..., sender=app.signer)
     ...
 ```

--- a/docs/userguides/platform.md
+++ b/docs/userguides/platform.md
@@ -1,14 +1,14 @@
-# Deploying Applications
+# Deploying Bots
 
 In this guide, we are going to show you more details on how to deploy your application to the [Silverback Platform](https://silverback.apeworx.io).
 
 ## Creating a Cluster
 
-The Silverback Platform runs your Applications (or "Bots") on dedicated managed application Clusters.
+The Silverback Platform runs your Bots on dedicated managed application Clusters.
 These Clusters will take care to orchestrate infrastructure, monitor, run your triggers, and collect metrics for your applications.
 Each Cluster is bespoke for an individual or organization, and isolates your applications from others on different infrastructure.
 
-Before we deploy our Application, we have to create a Cluster.
+Before we deploy our Bot, we have to create a Cluster.
 If you haven't yet, please sign up for Silverback at [https://silverback.apeworx.io](https://silverback.apeworx.io).
 
 Once you have signed up, you can actually create (and pay for) your Clusters from the Silverback CLI utility by first
@@ -44,7 +44,7 @@ For instance, to list all your available bots on your cluster, use [`silverback 
 To obtain general information about your cluster, just use [`silverback cluster info`][silverback-cluster-info],
 or [`silverback cluster health`][silverback-cluster-health] to see the current status of your Cluster.
 
-If you have no bots, we will first have to containerize our Applications and upload them to a container registry that our Cluster is configured to access.
+If you have no bots, we will first have to containerize our Bots and upload them to a container registry that our Cluster is configured to access.
 
 ```{note}
 Building a container for your application can be an advanced topic, we have included the `silverback build` subcommand to help assist in generating Dockerfiles.
@@ -108,7 +108,7 @@ Silverback Clusters include an environment variable management system for exactl
 which you can manage using [`silverback cluster vars`][silverback-cluster-vars] subcommand.
 
 The environment variable management system makes use of a concept called "Variable Groups" which are distinct collections of environment variables meant to be used together.
-These variable groups will help in managing the runtime environment of your Applications by allowing you to segregate different variables depending on each bot's needs.
+These variable groups will help in managing the runtime environment of your Bots by allowing you to segregate different variables depending on each bot's needs.
 
 To create an environment group, use the [`silverback cluster vars new`][silverback-cluster-vars-new] command and give it a name and a set of related variables.
 For instance, it may make sense to make a group of variables for your favorite Ape plugins or services, such as RPC Providers, Blockchain Data Indexers, Etherscan, etc.
@@ -199,7 +199,7 @@ Any task execution that experiences an error will abort execution (and therefore
 All errors encountered during task exeuction are reported to the Cluster for later review by any users with appriopiate access.
 Tasks do not retry (by default), but updates to `app.state` are maintained up until the point an error occurs.
 
-It is important to keep track of these errors and ensure that none of them are in fact critical to the operation of your Application,
+It is important to keep track of these errors and ensure that none of them are in fact critical to the operation of your Bot,
 and to take corrective or preventative action if it is determined that it should be treated as a more critical failure condition.
 ```
 

--- a/example.py
+++ b/example.py
@@ -46,7 +46,6 @@ def worker_startup(worker_state: TaskiqState):  # NOTE: You need the type hint t
     # NOTE: Worker state is per-worker, not shared with other workers
     # NOTE: Can put anything here, any python object works
     worker_state.db = MyDB()
-    worker_state.block_count = 0
 
     # Any exception raised on worker startup aborts immediately:
     # raise Exception  # NOTE: raises StartupFailure

--- a/example.py
+++ b/example.py
@@ -42,6 +42,7 @@ class MyDB:
 
 
 @app.on_worker_startup()
+# NOTE: This event is triggered internally, do not use unless you know what you're doing
 def worker_startup(worker_state: TaskiqState):  # NOTE: You need the type hint to load worker state
     # NOTE: Worker state is per-worker, not shared with other workers
     # NOTE: Can put anything here, any python object works

--- a/example.py
+++ b/example.py
@@ -83,15 +83,19 @@ def exec_event1(log):
 @app.on_(YFI.Approval)
 # Any handler function can be async too
 async def exec_event2(log: ContractLog):
-    if log.log_index % 7 == 6:
-        # If you ever want the app to immediately shutdown under some scenario, raise this exception
-        raise CircuitBreaker("Oopsie!")
-
     # All `app.state` values are updated across all workers at the same time
     app.state.logs_processed += 1
     # Do any other long running tasks...
     await asyncio.sleep(5)
     return log.amount
+
+
+@app.on_(chain.blocks)
+# NOTE: You can have multiple handlers for any trigger we support
+def check_logs(log):
+    if app.state.logs_processed > 20:
+        # If you ever want the app to immediately shutdown under some scenario, raise this exception
+        raise CircuitBreaker("Oopsie!")
 
 
 # A final job to execute on Silverback shutdown

--- a/example.py
+++ b/example.py
@@ -6,7 +6,7 @@ from ape.types import ContractLog
 from ape_tokens import tokens  # type: ignore[import]
 from taskiq import Context, TaskiqDepends, TaskiqState
 
-from silverback import AppState, CircuitBreaker, SilverbackApp
+from silverback import CircuitBreaker, SilverbackApp, StateSnapshot
 
 # Do this first to initialize your app
 app = SilverbackApp()
@@ -17,7 +17,7 @@ YFI = tokens["YFI"]
 
 
 @app.on_startup()
-def app_startup(startup_state: AppState):
+def app_startup(startup_state: StateSnapshot):
     # NOTE: This is called just as the app is put into "run" state,
     #       and handled by the first available worker
     # raise Exception  # NOTE: Any exception raised on startup aborts immediately

--- a/example.py
+++ b/example.py
@@ -7,29 +7,29 @@ from ape.types import ContractLog
 from ape_tokens import tokens  # type: ignore[import]
 from taskiq import Context, TaskiqDepends, TaskiqState
 
-from silverback import CircuitBreaker, SilverbackApp, StateSnapshot
+from silverback import CircuitBreaker, SilverbackBot, StateSnapshot
 
-# Do this first to initialize your app
-app = SilverbackApp()
+# Do this first to initialize your bot
+bot = SilverbackBot()
 
-# Cannot call `app.state` outside of an app function handler
-# app.state.something  # NOTE: raises AttributeError
+# Cannot call `bot.state` outside of an bot function handler
+# bot.state.something  # NOTE: raises AttributeError
 
-# NOTE: Don't do any networking until after initializing app
+# NOTE: Don't do any networking until after initializing bot
 USDC = tokens["USDC"]
 YFI = tokens["YFI"]
 
 
-@app.on_startup()
-def app_startup(startup_state: StateSnapshot):
-    # This is called just as the app is put into "run" state,
+@bot.on_startup()
+def bot_startup(startup_state: StateSnapshot):
+    # This is called just as the bot is put into "run" state,
     # and handled by the first available worker
 
     # Any exception raised on startup aborts immediately:
     # raise Exception  # NOTE: raises StartupFailure
 
-    # This is a great place to set `app.state` values
-    app.state.logs_processed = 0
+    # This is a great place to set `bot.state` values
+    bot.state.logs_processed = 0
     # NOTE: Can put anything here, any python object works
 
     return {"block_number": startup_state.last_block_seen}
@@ -41,7 +41,7 @@ class MyDB:
         pass  # Handle query somehow...
 
 
-@app.on_worker_startup()
+@bot.on_worker_startup()
 # NOTE: This event is triggered internally, do not use unless you know what you're doing
 def worker_startup(worker_state: TaskiqState):  # NOTE: You need the type hint to load worker state
     # NOTE: Worker state is per-worker, not shared with other workers
@@ -51,12 +51,12 @@ def worker_startup(worker_state: TaskiqState):  # NOTE: You need the type hint t
     # Any exception raised on worker startup aborts immediately:
     # raise Exception  # NOTE: raises StartupFailure
 
-    # Cannot call `app.state` because it is not set up yet on worker startup functions
-    # app.state.something  # NOTE: raises AttributeError
+    # Cannot call `bot.state` because it is not set up yet on worker startup functions
+    # bot.state.something  # NOTE: raises AttributeError
 
 
 # This is how we trigger off of new blocks
-@app.on_(chain.blocks)
+@bot.on_(chain.blocks)
 # NOTE: The type hint for block is `BlockAPI`, but we parse it using `EcosystemAPI`
 # NOTE: If you need something from worker state, you have to use taskiq context
 def exec_block(block: BlockAPI, context: Annotated[Context, TaskiqDepends()]):
@@ -66,48 +66,48 @@ def exec_block(block: BlockAPI, context: Annotated[Context, TaskiqDepends()]):
 
 # This is how we trigger off of events
 # Set new_block_timeout to adjust the expected block time.
-@app.on_(USDC.Transfer, start_block=19784367, new_block_timeout=25)
+@bot.on_(USDC.Transfer, start_block=19784367, new_block_timeout=25)
 # NOTE: Typing isn't required, it will still be an Ape `ContractLog` type
 def exec_event1(log):
     if log.log_index % 7 == 3:
         # If you raise any exception, Silverback will track the failure and keep running
-        # NOTE: By default, if you have 3 tasks fail in a row, the app will shutdown itself
+        # NOTE: By default, if you have 3 tasks fail in a row, the bot will shutdown itself
         raise ValueError("I don't like the number 3.")
 
     # You can update state whenever you want
-    app.state.logs_processed += 1
+    bot.state.logs_processed += 1
 
     return {"amount": log.amount}
 
 
-@app.on_(YFI.Approval)
+@bot.on_(YFI.Approval)
 # Any handler function can be async too
 async def exec_event2(log: ContractLog):
-    # All `app.state` values are updated across all workers at the same time
-    app.state.logs_processed += 1
+    # All `bot.state` values are updated across all workers at the same time
+    bot.state.logs_processed += 1
     # Do any other long running tasks...
     await asyncio.sleep(5)
     return log.amount
 
 
-@app.on_(chain.blocks)
+@bot.on_(chain.blocks)
 # NOTE: You can have multiple handlers for any trigger we support
 def check_logs(log):
-    if app.state.logs_processed > 20:
-        # If you ever want the app to immediately shutdown under some scenario, raise this exception
+    if bot.state.logs_processed > 20:
+        # If you ever want the bot to immediately shutdown under some scenario, raise this exception
         raise CircuitBreaker("Oopsie!")
 
 
 # A final job to execute on Silverback shutdown
-@app.on_shutdown()
-def app_shutdown():
+@bot.on_shutdown()
+def bot_shutdown():
     # NOTE: Any exception raised on worker shutdown is ignored:
     # raise Exception
     return {"some_metric": 123}
 
 
 # Just in case you need to release some resources or something inside each worker
-@app.on_worker_shutdown()
+@bot.on_worker_shutdown()
 def worker_shutdown(state: TaskiqState):  # NOTE: You need the type hint here
     # This is a good time to release resources
     state.db = None

--- a/silverback/__init__.py
+++ b/silverback/__init__.py
@@ -1,5 +1,5 @@
-from .main import SilverbackBot
 from .exceptions import CircuitBreaker, SilverbackException
+from .main import SilverbackBot
 from .state import StateSnapshot
 
 __all__ = [

--- a/silverback/__init__.py
+++ b/silverback/__init__.py
@@ -1,9 +1,9 @@
 from .application import SilverbackApp
 from .exceptions import CircuitBreaker, SilverbackException
-from .state import AppState
+from .state import StateSnapshot
 
 __all__ = [
-    "AppState",
+    "StateSnapshot",
     "CircuitBreaker",
     "SilverbackApp",
     "SilverbackException",

--- a/silverback/__init__.py
+++ b/silverback/__init__.py
@@ -1,10 +1,10 @@
-from .application import SilverbackApp
+from .main import SilverbackBot
 from .exceptions import CircuitBreaker, SilverbackException
 from .state import StateSnapshot
 
 __all__ = [
     "StateSnapshot",
     "CircuitBreaker",
-    "SilverbackApp",
+    "SilverbackBot",
     "SilverbackException",
 ]

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -51,7 +51,7 @@ RUN ape plugins install .
 @click.group(cls=SectionedHelpGroup)
 def cli():
     """
-    Silverback: Build Python apps that react to on-chain events
+    Silverback: Build Python bots that react to on-chain events
 
     To learn more about our cloud offering, please check out https://silverback.apeworx.io
     """
@@ -110,7 +110,7 @@ def _network_callback(ctx, param, val):
 @click.option("-x", "--max-exceptions", type=int, default=3)
 @click.argument("bot", required=False, callback=bot_path_callback)
 def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, bot):
-    """Run Silverback application"""
+    """Run Silverback bot"""
 
     if not runner_class:
         # NOTE: Automatically select runner class
@@ -120,7 +120,7 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, bot):
             runner_class = PollingRunner
         else:
             raise click.BadOptionUsage(
-                option_name="network", message="Network choice cannot support running app"
+                option_name="network", message="Network choice cannot support running bot"
             )
 
     runner = runner_class(
@@ -213,7 +213,7 @@ def login(auth: FiefAuth):
 
 @cli.group(cls=SectionedHelpGroup, section="Cloud Commands (https://silverback.apeworx.io)")
 def cluster():
-    """Manage a Silverback hosted application cluster
+    """Manage a Silverback hosted bot cluster
 
     For clusters on the Silverback Platform, please provide a name for the cluster to access under
     your platform account via `-c WORKSPACE/NAME`"""

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -48,11 +48,11 @@ class NoTasksAvailableError(SilverbackException):
 
 class Halt(SilverbackException):
     def __init__(self):
-        super().__init__("App halted, must restart manually")
+        super().__init__("Bot halted, must restart manually")
 
 
 class CircuitBreaker(Halt):
-    """Custom exception (created by user) that will trigger an application shutdown."""
+    """Custom exception (created by user) that will trigger an bot shutdown."""
 
     def __init__(self, message: str):
         super(SilverbackException, self).__init__(message)

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -85,7 +85,12 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
             message.labels["transaction_hash"] = log.transaction_hash
             message.labels["log_index"] = str(log.log_index)
 
-        logger.info(f"{self._create_label(message)} - Started")
+        msg = f"{self._create_label(message)} - Started"
+        if message.task_name.startswith("system:"):
+            logger.debug(msg)
+        else:
+            logger.info(msg)
+
         return message
 
     def post_execute(self, message: TaskiqMessage, result: TaskiqResult):

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -253,7 +253,7 @@ class BaseRunner(ABC):
         )
 
         if shutdown_taskdata_result.is_err:
-            raise StartupFailure(shutdown_taskdata_result.error)
+            logger.error(f"Error when collecting shutdown tasks:\n{shutdown_taskdata_result.error}")
 
         else:
             shutdown_task_handlers = map(

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -14,7 +14,7 @@ from taskiq.kicker import AsyncKicker
 from .application import SilverbackApp, SystemConfig, TaskData
 from .exceptions import Halt, NoTasksAvailableError, NoWebsocketAvailableError, StartupFailure
 from .recorder import BaseRecorder, TaskResult
-from .state import AppDatastore, AppState
+from .state import AppDatastore, StateSnapshot
 from .subscriptions import SubscriptionType, Web3SubscriptionsManager
 from .types import TaskType
 from .utils import (
@@ -160,7 +160,7 @@ class BaseRunner(ABC):
             self.state = startup_state
 
         else:  # use empty state
-            self.state = AppState(last_block_seen=-1, last_block_processed=-1)
+            self.state = StateSnapshot(last_block_seen=-1, last_block_processed=-1)
 
         # Execute Silverback startup task before we init the rest
         startup_taskdata_result = await run_taskiq_task_wait_result(

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -14,7 +14,7 @@ from taskiq.kicker import AsyncKicker
 from .application import SilverbackApp, SystemConfig, TaskData
 from .exceptions import Halt, NoTasksAvailableError, NoWebsocketAvailableError, StartupFailure
 from .recorder import BaseRecorder, TaskResult
-from .state import AppDatastore, StateSnapshot
+from .state import StateSnapshot
 from .subscriptions import SubscriptionType, Web3SubscriptionsManager
 from .types import TaskType
 from .utils import (
@@ -37,8 +37,6 @@ class BaseRunner(ABC):
     ):
         self.app = app
         self.recorder = recorder
-        self.state = None
-        self.datastore = AppDatastore()
 
         self.max_exceptions = max_exceptions
         self.exceptions = 0
@@ -76,26 +74,12 @@ class BaseRunner(ABC):
         last_block_processed: int | None = None,
     ):
         """Set latest checkpoint block number"""
-        assert self.state, f"{self.__class__.__name__}.run() not triggered."
+        if not self.save_snapshot_supported:
+            return  # Can't support this feature
 
-        logger.debug(
-            (
-                f"Checkpoint block [seen={self.state.last_block_seen}, "
-                f"procssed={self.state.last_block_processed}]"
-            )
-        )
-
-        if last_block_seen:
-            self.state.last_block_seen = last_block_seen
-        if last_block_processed:
-            self.state.last_block_processed = last_block_processed
-
-        if self.recorder:
-            try:
-                await self.datastore.set_state(self.state)
-
-            except Exception as err:
-                logger.error(f"Error setting state: {err}")
+        task = await self.app._save_snapshot.kiq(last_block_seen, last_block_processed)
+        if (result := await task.wait_result()).is_err:
+            logger.error(f"Error saving snapshot: {result.error}")
 
     @abstractmethod
     async def _block_task(self, task_data: TaskData):
@@ -106,7 +90,7 @@ class BaseRunner(ABC):
     @abstractmethod
     async def _event_task(self, task_data: TaskData):
         """
-        handle an event handler task for the given contract event
+        Handle an event handler task for the given contract event
         """
 
     async def run(self):
@@ -148,19 +132,40 @@ class BaseRunner(ABC):
             f", available task types:\n- {system_tasks_str}"
         )
 
+        # NOTE: Bypass snapshotting if unsupported
+        self.save_snapshot_supported = TaskType.SYSTEM_SAVE_SNAPSHOT in system_tasks
+
+        # Load the snapshot (if available)
+        # NOTE: Add some additional handling to see if this feature is available in bot
+        if TaskType.SYSTEM_LOAD_SNAPSHOT not in system_tasks:
+            logger.warning(
+                "Silverback no longer supports runner-based snapshotting, "
+                "please upgrade your bot SDK version to latest."
+            )
+            startup_state = StateSnapshot(
+                last_block_seen=-1,
+                last_block_processed=-1,
+            )  # Use empty snapshot
+
+        elif (
+            result := await run_taskiq_task_wait_result(
+                self._create_system_task_kicker(TaskType.SYSTEM_LOAD_SNAPSHOT)
+            )
+        ).is_err:
+            raise StartupFailure(result.error)
+
+        else:
+            startup_state = result.return_value
+            logger.debug(f"Startup state: {startup_state}")
+        # NOTE: State snapshot is immediately out of date after init
+
         # NOTE: Do this for other system tasks because they may not be in older SDK versions
         #       `if TaskType.<SYSTEM_TASK_NAME> not in system_tasks: raise StartupFailure(...)`
         #       or handle accordingly by having default logic if it is not available
 
-        # Initialize recorder (if available) and fetch state if app has been run previously
+        # Initialize recorder (if available)
         if self.recorder:
             await self.recorder.init(app_id=self.app.identifier)
-
-        if startup_state := (await self.datastore.init(app_id=self.app.identifier)):
-            self.state = startup_state
-
-        else:  # use empty state
-            self.state = StateSnapshot(last_block_seen=-1, last_block_processed=-1)
 
         # Execute Silverback startup task before we init the rest
         startup_taskdata_result = await run_taskiq_task_wait_result(
@@ -176,7 +181,7 @@ class BaseRunner(ABC):
             )
 
             startup_task_results = await run_taskiq_task_group_wait_results(
-                (task_handler for task_handler in startup_task_handlers), self.state
+                (task_handler for task_handler in startup_task_handlers), startup_state
             )
 
             if any(result.is_err for result in startup_task_results):

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -11,8 +11,8 @@ from packaging.version import Version
 from taskiq import AsyncTaskiqTask
 from taskiq.kicker import AsyncKicker
 
-from .main import SilverbackBot, SystemConfig, TaskData
 from .exceptions import Halt, NoTasksAvailableError, NoWebsocketAvailableError, StartupFailure
+from .main import SilverbackBot, SystemConfig, TaskData
 from .recorder import BaseRecorder, TaskResult
 from .state import Datastore, StateSnapshot
 from .subscriptions import SubscriptionType, Web3SubscriptionsManager

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -19,14 +19,14 @@ from .recorder import BaseRecorder
 
 class Settings(BaseSettings, ManagerAccessMixin):
     """
-    Settings for the Silverback app.
+    Settings for the Silverback bot.
 
     Can override these settings from a default state, typically for advanced
     testing or deployment purposes. Defaults to a working in-memory broker.
     """
 
     # A unique identifier for this silverback instance
-    APP_NAME: str = "bot"
+    BOT_NAME: str = "bot"
 
     BROKER_CLASS: str = "taskiq:InMemoryBroker"
     BROKER_URI: str = ""  # To be deprecated in 0.6
@@ -122,7 +122,7 @@ class Settings(BaseSettings, ManagerAccessMixin):
             acct_idx = int(alias.replace("TEST::", ""))
             return self.account_manager.test_accounts[acct_idx]
 
-        # NOTE: Will only have a signer if assigned one here (or in app)
+        # NOTE: Will only have a signer if assigned one here (or in bot)
         signer = self.account_manager.load(alias)
 
         # NOTE: Set autosign if it's a keyfile account (for local testing)

--- a/silverback/state.py
+++ b/silverback/state.py
@@ -17,30 +17,30 @@ class StateSnapshot(BaseModel):
     last_updated: UTCTimestamp = Field(default_factory=utc_now)
 
 
-class AppDatastore:
+class Datastore:
     """
-    Very basic implementation used to store application state and handler result data by
+    Very basic implementation used to store bot state and handler result data by
     storing/retreiving state from a JSON-encoded file.
 
-    The file structure that this Recorder uses leverages the value of `SILVERBACK_APP_NAME`
+    The file structure that this Recorder uses leverages the value of `SILVERBACK_BOT_NAME`
     as well as the configured network to determine the location where files get saved:
 
         ./.silverback-sessions/
-          <app-name>/
+          <bot-name>/
             <network choice>/
               state.json  # always write here
 
     Note that this format can be read by basic means (even in a JS frontend):
 
-    You may also want to give your app a unique name so the data does not get overwritten,
-    if you are using multiple apps from the same directory:
+    You may also want to give your bot a unique name so the data does not get overwritten,
+    if you are using multiple bots from the same directory:
 
-    - `SILVERBACK_APP_NAME`: Any alphabetical string valid as a folder name
+    - `SILVERBACK_BOT_NAME`: Any alphabetical string valid as a folder name
     """
 
-    async def init(self, app_id: SilverbackID) -> StateSnapshot | None:
+    async def init(self, bot_id: SilverbackID) -> StateSnapshot | None:
         data_folder = (
-            Path.cwd() / ".silverback-sessions" / app_id.name / app_id.ecosystem / app_id.network
+            Path.cwd() / ".silverback-sessions" / bot_id.name / bot_id.ecosystem / bot_id.network
         )
         data_folder.mkdir(parents=True, exist_ok=True)
         self.state_backup_file = data_folder / "state.json"

--- a/silverback/state.py
+++ b/silverback/state.py
@@ -43,7 +43,6 @@ class AppDatastore:
             Path.cwd() / ".silverback-sessions" / app_id.name / app_id.ecosystem / app_id.network
         )
         data_folder.mkdir(parents=True, exist_ok=True)
-
         self.state_backup_file = data_folder / "state.json"
 
         return (
@@ -53,12 +52,4 @@ class AppDatastore:
         )
 
     async def save(self, snapshot: StateSnapshot):
-        if self.state_backup_file.exists():
-            old_snapshot = AppState.parse_file(self.snapshot_backup_file)
-            if old_snapshot.last_block_seen > snapshot.last_block_seen:
-                snapshot.last_block_seen = old_snapshot.last_block_seen
-            if old_snapshot.last_block_processed > snapshot.last_block_processed:
-                snapshot.last_block_processed = old_snapshot.last_block_processed
-
-        snapshot.last_updated = utc_now()
         self.state_backup_file.write_text(snapshot.model_dump_json())

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -17,7 +17,7 @@ class TaskType(str, Enum):
     SYSTEM_USER_TASKDATA = "system:user-taskdata"
     SYSTEM_USER_ALL_TASKDATA = "system:user-all-taskdata"
     SYSTEM_LOAD_SNAPSHOT = "system:load-snapshot"
-    SYSTEM_SAVE_SNAPSHOT = "system:save-snapshot"
+    SYSTEM_CREATE_SNAPSHOT = "system:create-snapshot"
 
     # User-accessible Tasks
     STARTUP = "user:startup"

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -16,6 +16,8 @@ class TaskType(str, Enum):
     SYSTEM_CONFIG = "system:config"
     SYSTEM_USER_TASKDATA = "system:user-taskdata"
     SYSTEM_USER_ALL_TASKDATA = "system:user-all-taskdata"
+    SYSTEM_LOAD_SNAPSHOT = "system:load-snapshot"
+    SYSTEM_SAVE_SNAPSHOT = "system:save-snapshot"
 
     # User-accessible Tasks
     STARTUP = "user:startup"


### PR DESCRIPTION
### What I did

This PR adds worker shared state (accessible via `app.state`) and adds 2 new system tasks to support loading and storing a snapshot of that managed state. Currently this is just `last_block_processed` and `last_block_seen`.

This paves the way for the `Parameter` feature, but does not include that just yet.

BREAKING CHANGE: state snapshot features migrates from runner to worker and must be triggered by runner

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
