### PR TITLE
feat!: stateless runner

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "eth-ape>=0.7,<1.0",
         "ethpm-types>=0.6.10",  # lower pin only, `eth-ape` governs upper pin
         "eth-pydantic-types",  # Use same version as eth-ape
+        "packaging",  # Use same version as eth-ape
         "pydantic_settings",  # Use same version as eth-ape
         "taskiq[metrics]>=0.11.3,<0.12",
     ],

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -32,7 +32,6 @@ class TaskData(BaseModel):
     labels: dict[str, Any]
 
     # NOTE: Any other items here must have a default value
-    event_abi: EventABI | None = None
 
 
 class SilverbackApp(ManagerAccessMixin):
@@ -188,15 +187,9 @@ class SilverbackApp(ManagerAccessMixin):
                     )
 
                 labels["contract_address"] = contract_address
-                labels["event_name"] = container.abi.name
-                event_abi = container.abi
+                labels["event_signature"] = container.abi.signature
 
-            else:
-                event_abi = None
-
-            self.tasks[task_type].append(
-                TaskData(name=handler.__name__, labels=labels, event_abi=event_abi)
-            )
+            self.tasks[task_type].append(TaskData(name=handler.__name__, labels=labels))
 
             return self.broker.register_task(
                 handler,

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -7,7 +7,6 @@ from ape.contracts import ContractEvent, ContractInstance
 from ape.logging import logger
 from ape.managers.chain import BlockContainer
 from ape.utils import ManagerAccessMixin
-from ethpm_types import EventABI
 from packaging.version import Version
 from pydantic import BaseModel
 from taskiq import AsyncTaskiqDecoratedTask, TaskiqEvents

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -160,12 +160,12 @@ class SilverbackApp(ManagerAccessMixin):
                 type it should handle.
         """
         if (
-            (task_type is TaskType.NEW_BLOCKS and not isinstance(container, BlockContainer))
+            (task_type is TaskType.NEW_BLOCK and not isinstance(container, BlockContainer))
             or (task_type is TaskType.EVENT_LOG and not isinstance(container, ContractEvent))
             or (
                 task_type
                 not in (
-                    TaskType.NEW_BLOCKS,
+                    TaskType.NEW_BLOCK,
                     TaskType.EVENT_LOG,
                 )
                 and container is not None
@@ -287,7 +287,7 @@ class SilverbackApp(ManagerAccessMixin):
                 else:
                     self.poll_settings["_blocks_"] = {"start_block": start_block}
 
-            return self.broker_task_decorator(TaskType.NEW_BLOCKS, container=container)
+            return self.broker_task_decorator(TaskType.NEW_BLOCK, container=container)
 
         elif isinstance(container, ContractEvent) and isinstance(
             container.contract, ContractInstance

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -91,10 +91,8 @@ class SilverbackApp(ManagerAccessMixin):
 
         self.signer = settings.get_signer()
         self.new_block_timeout = settings.NEW_BLOCK_TIMEOUT
-        self.start_block = settings.START_BLOCK
 
         signer_str = f"\n  SIGNER={repr(self.signer)}"
-        start_block_str = f"\n  START_BLOCK={self.start_block}" if self.start_block else ""
         new_block_timeout_str = (
             f"\n  NEW_BLOCK_TIMEOUT={self.new_block_timeout}" if self.new_block_timeout else ""
         )
@@ -102,7 +100,7 @@ class SilverbackApp(ManagerAccessMixin):
         network_choice = f"{self.identifier.ecosystem}:{self.identifier.network}"
         logger.success(
             f'Loaded Silverback App:\n  NETWORK="{network_choice}"'
-            f"{signer_str}{start_block_str}{new_block_timeout_str}"
+            f"{signer_str}{new_block_timeout_str}"
         )
 
         # NOTE: Runner must call this to configure itself for all SDK hooks

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -1,4 +1,4 @@
-from typing import Any, Sequence
+from typing import Any
 
 from ape.exceptions import ApeException
 
@@ -32,8 +32,10 @@ class SilverbackException(ApeException):
 
 # TODO: `ExceptionGroup` added in Python 3.11
 class StartupFailure(SilverbackException):
-    def __init__(self, *exceptions: Sequence[Exception]):
-        if error_str := "\n".join(str(e) for e in exceptions):
+    def __init__(self, *exceptions: Exception | str):
+        if len(exceptions) == 1 and isinstance(exceptions[0], str):
+            super().__init__(exceptions[0])
+        elif error_str := "\n".join(str(e) for e in exceptions):
             super().__init__(f"Startup failure(s):\n{error_str}")
         else:
             super().__init__("Startup failure(s) detected. See logs for details.")

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -96,8 +96,12 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
         else:
             percent_display = ""
 
-        (logger.error if result.error else logger.success)(
-            f"{self._create_label(message)} " f"- {result.execution_time:.3f}s{percent_display}"
-        )
+        msg = f"{self._create_label(message)} " f"- {result.execution_time:.3f}s{percent_display}"
+        if result.is_err:
+            logger.error(msg)
+        elif message.task_name.startswith("system:"):
+            logger.debug(msg)
+        else:
+            logger.success(msg)
 
     # NOTE: Unless stdout is ignored, error traceback appears in stdout, no need for `on_error`

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -70,7 +70,7 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
             return message  # Not a silverback task
 
         # Add extra labels for our task to see what their source was
-        if task_type is TaskType.NEW_BLOCKS:
+        if task_type is TaskType.NEW_BLOCK:
             # NOTE: Necessary because we don't know the exact block class
             block = message.args[0] = self.provider.network.ecosystem.decode_block(
                 hexbytes_dict(message.args[0])

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -348,18 +348,15 @@ class PollingRunner(BaseRunner, ManagerAccessMixin):
 
         if block_settings := self.app.poll_settings.get("_blocks_"):
             new_block_timeout = block_settings.get("new_block_timeout")
-            start_block = block_settings.get("start_block")
         else:
             new_block_timeout = None
-            start_block = None
 
         new_block_timeout = (
             new_block_timeout if new_block_timeout is not None else self.app.new_block_timeout
         )
-        start_block = start_block if start_block is not None else self.app.start_block
         async for block in async_wrap_iter(
             chain.blocks.poll_blocks(
-                start_block=start_block,
+                # NOTE: No start block because we should begin polling from head
                 new_block_timeout=new_block_timeout,
             )
         ):
@@ -377,18 +374,15 @@ class PollingRunner(BaseRunner, ManagerAccessMixin):
         event_log_task_kicker = self._create_task_kicker(task_data)
         if address_settings := self.app.poll_settings.get(contract_address):
             new_block_timeout = address_settings.get("new_block_timeout")
-            start_block = address_settings.get("start_block")
         else:
             new_block_timeout = None
-            start_block = self.app.start_block
 
         new_block_timeout = (
             new_block_timeout if new_block_timeout is not None else self.app.new_block_timeout
         )
-        start_block = start_block if start_block is not None else self.app.start_block
         async for event in async_wrap_iter(
             self.provider.poll_logs(
-                start_block=start_block,
+                # NOTE: No start block because we should begin polling from head
                 address=contract_address,
                 new_block_timeout=new_block_timeout,
                 events=[event_abi],

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -192,7 +192,7 @@ class BaseRunner(ABC):
 
         # Create our long-running event listeners
         new_block_taskdata_results = await run_taskiq_task_wait_result(
-            self._create_system_task_kicker(TaskType.SYSTEM_USER_TASKDATA), TaskType.NEW_BLOCKS
+            self._create_system_task_kicker(TaskType.SYSTEM_USER_TASKDATA), TaskType.NEW_BLOCK
         )
         if new_block_taskdata_results.is_err:
             raise StartupFailure(new_block_taskdata_results.error)

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -133,7 +133,7 @@ class BaseRunner(ABC):
             raise StartupFailure("Unable to determine system configuration of worker")
 
         # NOTE: Increase the specifier set here if there is a breaking change to this
-        if Version(result.return_value.sdk_version) not in SpecifierSet(">=0.4.1"):
+        if Version(result.return_value.sdk_version) not in SpecifierSet(">=0.5.0"):
             # TODO: set to next breaking change release before release
             raise StartupFailure("Worker SDK version too old, please rebuild")
 

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -2,26 +2,32 @@ import asyncio
 from abc import ABC, abstractmethod
 
 from ape import chain
-from ape.contracts import ContractEvent, ContractInstance
 from ape.logging import logger
 from ape.utils import ManagerAccessMixin
 from ape_ethereum.ecosystem import keccak
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
-from taskiq import AsyncTaskiqDecoratedTask, AsyncTaskiqTask
+from taskiq import AsyncTaskiqTask
+from taskiq.kicker import AsyncKicker
 
-from .application import SilverbackApp, SystemConfig
+from .application import SilverbackApp, SystemConfig, TaskData
 from .exceptions import Halt, NoTasksAvailableError, NoWebsocketAvailableError, StartupFailure
 from .recorder import BaseRecorder, TaskResult
 from .state import AppDatastore, AppState
 from .subscriptions import SubscriptionType, Web3SubscriptionsManager
 from .types import TaskType
-from .utils import async_wrap_iter, hexbytes_dict, run_taskiq_task_wait_result
+from .utils import (
+    async_wrap_iter,
+    hexbytes_dict,
+    run_taskiq_task_group_wait_results,
+    run_taskiq_task_wait_result,
+)
 
 
 class BaseRunner(ABC):
     def __init__(
         self,
+        # TODO: Make fully stateless by replacing `app` with `broker` and `identifier`
         app: SilverbackApp,
         *args,
         max_exceptions: int = 3,
@@ -37,6 +43,15 @@ class BaseRunner(ABC):
         self.exceptions = 0
 
         logger.info(f"Using {self.__class__.__name__}: max_exceptions={self.max_exceptions}")
+
+    def _create_task_kicker(self, task_data: TaskData) -> AsyncKicker:
+        return AsyncKicker(
+            task_name=task_data.name, broker=self.app.broker, labels=task_data.labels
+        )
+
+    def _create_system_task_kicker(self, task_type: TaskType) -> AsyncKicker:
+        assert "system:" in str(task_type)
+        return self._create_task_kicker(TaskData(name=str(task_type), labels={}))
 
     async def _handle_task(self, task: AsyncTaskiqTask):
         result = await task.wait_result()
@@ -82,15 +97,13 @@ class BaseRunner(ABC):
                 logger.error(f"Error setting state: {err}")
 
     @abstractmethod
-    async def _block_task(self, block_handler: AsyncTaskiqDecoratedTask):
+    async def _block_task(self, task_data: TaskData):
         """
         Handle a block_handler task
         """
 
     @abstractmethod
-    async def _event_task(
-        self, contract_event: ContractEvent, event_handler: AsyncTaskiqDecoratedTask
-    ):
+    async def _event_task(self, task_data: TaskData):
         """
         handle an event handler task for the given contract event
         """
@@ -112,7 +125,9 @@ class BaseRunner(ABC):
         await self.app.broker.startup()
 
         # Obtain system configuration for worker
-        result = await run_taskiq_task_wait_result(self.app._get_system_config)
+        result = await run_taskiq_task_wait_result(
+            self._create_system_task_kicker(TaskType.SYSTEM_CONFIG)
+        )
         if result.is_err or not isinstance(result.return_value, SystemConfig):
             raise StartupFailure("Unable to determine system configuration of worker")
 
@@ -147,38 +162,68 @@ class BaseRunner(ABC):
             self.state = AppState(last_block_seen=-1, last_block_processed=-1)
 
         # Execute Silverback startup task before we init the rest
-        if startup_tasks := await asyncio.gather(
-            *(task_def.handler.kiq(self.state) for task_def in self.app.tasks[TaskType.STARTUP])
-        ):
-            results = await asyncio.gather(
-                *(startup_task.wait_result() for startup_task in startup_tasks)
+        startup_taskdata_result = await run_taskiq_task_wait_result(
+            self._create_system_task_kicker(TaskType.SYSTEM_USER_TASKDATA), TaskType.STARTUP
+        )
+
+        if startup_taskdata_result.is_err:
+            raise StartupFailure(startup_taskdata_result.error)
+
+        else:
+            startup_task_handlers = map(
+                self._create_task_kicker, startup_taskdata_result.return_value
             )
 
-            if any(result.is_err for result in results):
+            startup_task_results = await run_taskiq_task_group_wait_results(
+                (task_handler for task_handler in startup_task_handlers), self.state
+            )
+
+            if any(result.is_err for result in startup_task_results):
                 # NOTE: Abort before even starting to run
-                raise StartupFailure(*(result.error for result in results if result.is_err))
+                raise StartupFailure(
+                    *(result.error for result in startup_task_results if result.is_err)
+                )
 
             elif self.recorder:
-                converted_results = map(TaskResult.from_taskiq, results)
+                converted_results = map(TaskResult.from_taskiq, startup_task_results)
                 await asyncio.gather(*(self.recorder.add_result(r) for r in converted_results))
 
             # NOTE: No need to handle results otherwise
 
         # Create our long-running event listeners
+        new_block_taskdata_results = await run_taskiq_task_wait_result(
+            self._create_system_task_kicker(TaskType.SYSTEM_USER_TASKDATA), TaskType.NEW_BLOCKS
+        )
+        if new_block_taskdata_results.is_err:
+            raise StartupFailure(new_block_taskdata_results.error)
+
+        event_log_taskdata_results = await run_taskiq_task_wait_result(
+            self._create_system_task_kicker(TaskType.SYSTEM_USER_TASKDATA), TaskType.EVENT_LOG
+        )
+        if event_log_taskdata_results.is_err:
+            raise StartupFailure(event_log_taskdata_results.error)
+
+        if (
+            len(new_block_taskdata_results.return_value)
+            == len(event_log_taskdata_results.return_value)
+            == 0  # Both are empty
+        ):
+            raise NoTasksAvailableError()
+
         # NOTE: Any propagated failure in here should be handled such that shutdown tasks also run
         # TODO: `asyncio.TaskGroup` added in Python 3.11
         listener_tasks = (
             *(
-                asyncio.create_task(self._block_task(task_def.handler))
-                for task_def in self.app.tasks[TaskType.NEW_BLOCKS]
+                asyncio.create_task(self._block_task(task_def))
+                for task_def in new_block_taskdata_results.return_value
             ),
             *(
-                asyncio.create_task(self._event_task(task_def.container, task_def.handler))
-                for task_def in self.app.tasks[TaskType.EVENT_LOG]
+                asyncio.create_task(self._event_task(task_def))
+                for task_def in event_log_taskdata_results.return_value
             ),
         )
 
-        # NOTE: Safe to do this because no tasks have been scheduled to run yet
+        # NOTE: Safe to do this because no tasks were actually scheduled to run
         if len(listener_tasks) == 0:
             raise NoTasksAvailableError()
 
@@ -195,16 +240,30 @@ class BaseRunner(ABC):
         # NOTE: All listener tasks are shut down now
 
         # Execute Silverback shutdown task(s) before shutting down the broker and app
-        if shutdown_tasks := await asyncio.gather(
-            *(task_def.handler.kiq() for task_def in self.app.tasks[TaskType.SHUTDOWN])
-        ):
-            asyncio.gather(*(shutdown_task.is_ready() for shutdown_task in shutdown_tasks))
-            if any(result.is_err for result in results):
-                errors_str = "\n".join(str(result.error) for result in results if result.is_err)
+        shutdown_taskdata_result = await run_taskiq_task_wait_result(
+            self._create_system_task_kicker(TaskType.SYSTEM_USER_TASKDATA), TaskType.SHUTDOWN
+        )
+
+        if shutdown_taskdata_result.is_err:
+            raise StartupFailure(shutdown_taskdata_result.error)
+
+        else:
+            shutdown_task_handlers = map(
+                self._create_task_kicker, shutdown_taskdata_result.return_value
+            )
+
+            shutdown_task_results = await run_taskiq_task_group_wait_results(
+                (task_handler for task_handler in shutdown_task_handlers)
+            )
+
+            if any(result.is_err for result in shutdown_task_results):
+                errors_str = "\n".join(
+                    str(result.error) for result in shutdown_task_results if result.is_err
+                )
                 logger.error(f"Errors while shutting down:\n{errors_str}")
 
             elif self.recorder:
-                converted_results = map(TaskResult.from_taskiq, results)
+                converted_results = map(TaskResult.from_taskiq, shutdown_task_results)
                 await asyncio.gather(*(self.recorder.add_result(r) for r in converted_results))
 
             # NOTE: No need to handle results otherwise
@@ -221,12 +280,13 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
         super().__init__(app, *args, **kwargs)
 
         # Check for websocket support
-        if not (ws_uri := app.chain_manager.provider.ws_uri):
+        if not (ws_uri := self.chain_manager.provider.ws_uri):
             raise NoWebsocketAvailableError()
 
         self.ws_uri = ws_uri
 
-    async def _block_task(self, block_handler: AsyncTaskiqDecoratedTask):
+    async def _block_task(self, task_data: TaskData):
+        new_block_task_kicker = self._create_task_kicker(task_data)
         sub_id = await self.subscriptions.subscribe(SubscriptionType.BLOCKS)
         logger.debug(f"Handling blocks via {sub_id}")
 
@@ -234,35 +294,32 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
             block = self.provider.network.ecosystem.decode_block(hexbytes_dict(raw_block))
 
             await self._checkpoint(last_block_seen=block.number)
-            await self._handle_task(await block_handler.kiq(raw_block))
+            await self._handle_task(await new_block_task_kicker.kiq(raw_block))
             await self._checkpoint(last_block_processed=block.number)
 
-    async def _event_task(
-        self, contract_event: ContractEvent, event_handler: AsyncTaskiqDecoratedTask
-    ):
-        if not isinstance(contract_event.contract, ContractInstance):
-            # For type-checking.
-            raise ValueError("Contract instance required.")
+    async def _event_task(self, task_data: TaskData):
+        if not (contract_address := task_data.labels.get("contract_address")):
+            raise StartupFailure("Contract instance required.")
+
+        if not (event_abi := task_data.event_abi):
+            raise StartupFailure("No Event ABI provided.")
+
+        event_log_task_kicker = self._create_task_kicker(task_data)
 
         sub_id = await self.subscriptions.subscribe(
             SubscriptionType.EVENTS,
-            address=contract_event.contract.address,
-            topics=["0x" + keccak(text=contract_event.abi.selector).hex()],
+            address=contract_address,
+            topics=["0x" + keccak(text=event_abi.selector).hex()],
         )
-        logger.debug(
-            f"Handling '{contract_event.contract.address}:{contract_event.name}' logs via {sub_id}"
-        )
+        logger.debug(f"Handling '{contract_address}:{event_abi.name}' logs via {sub_id}")
 
         async for raw_event in self.subscriptions.get_subscription_data(sub_id):
             event = next(  # NOTE: `next` is okay since it only has one item
-                self.provider.network.ecosystem.decode_logs(
-                    [raw_event],
-                    contract_event.abi,
-                )
+                self.provider.network.ecosystem.decode_logs([raw_event], event_abi)
             )
 
             await self._checkpoint(last_block_seen=event.block_number)
-            await self._handle_task(await event_handler.kiq(event))
+            await self._handle_task(await event_log_task_kicker.kiq(event))
             await self._checkpoint(last_block_processed=event.block_number)
 
     async def run(self):
@@ -271,10 +328,13 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
             await super().run()
 
 
-class PollingRunner(BaseRunner):
+class PollingRunner(BaseRunner, ManagerAccessMixin):
     """
     Run a single app against a live network using a basic in-memory queue.
     """
+
+    # TODO: Move block_timeout settings to Ape core config
+    # TODO: Merge polling/websocket subscriptions downstream in Ape core
 
     def __init__(self, app: SilverbackApp, *args, **kwargs):
         super().__init__(app, *args, **kwargs)
@@ -283,45 +343,57 @@ class PollingRunner(BaseRunner):
             "Do not use in production over long time periods unless you know what you're doing."
         )
 
-    async def _block_task(self, block_handler: AsyncTaskiqDecoratedTask):
-        new_block_timeout = None
-        start_block = None
-        if "_blocks_" in self.app.poll_settings:
-            block_settings = self.app.poll_settings["_blocks_"]
+    async def _block_task(self, task_data: TaskData):
+        new_block_task_kicker = self._create_task_kicker(task_data)
+
+        if block_settings := self.app.poll_settings.get("_blocks_"):
             new_block_timeout = block_settings.get("new_block_timeout")
             start_block = block_settings.get("start_block")
+        else:
+            new_block_timeout = None
+            start_block = None
 
         new_block_timeout = (
             new_block_timeout if new_block_timeout is not None else self.app.new_block_timeout
         )
         start_block = start_block if start_block is not None else self.app.start_block
         async for block in async_wrap_iter(
-            chain.blocks.poll_blocks(start_block=start_block, new_block_timeout=new_block_timeout)
+            chain.blocks.poll_blocks(
+                start_block=start_block,
+                new_block_timeout=new_block_timeout,
+            )
         ):
             await self._checkpoint(last_block_seen=block.number)
-            await self._handle_task(await block_handler.kiq(block))
+            await self._handle_task(await new_block_task_kicker.kiq(block))
             await self._checkpoint(last_block_processed=block.number)
 
-    async def _event_task(
-        self, contract_event: ContractEvent, event_handler: AsyncTaskiqDecoratedTask
-    ):
-        new_block_timeout = None
-        start_block = None
-        address = None
-        if isinstance(contract_event.contract, ContractInstance):
-            address = contract_event.contract.address
-            if address in self.app.poll_settings:
-                address_settings = self.app.poll_settings[address]
-                new_block_timeout = address_settings.get("new_block_timeout")
-                start_block = address_settings.get("start_block")
+    async def _event_task(self, task_data: TaskData):
+        if not (contract_address := task_data.labels.get("contract_address")):
+            raise StartupFailure("Contract instance required.")
+
+        if not (event_abi := task_data.event_abi):
+            raise StartupFailure("No Event ABI provided.")
+
+        event_log_task_kicker = self._create_task_kicker(task_data)
+        if address_settings := self.app.poll_settings.get(contract_address):
+            new_block_timeout = address_settings.get("new_block_timeout")
+            start_block = address_settings.get("start_block")
+        else:
+            new_block_timeout = None
+            start_block = self.app.start_block
 
         new_block_timeout = (
             new_block_timeout if new_block_timeout is not None else self.app.new_block_timeout
         )
         start_block = start_block if start_block is not None else self.app.start_block
         async for event in async_wrap_iter(
-            contract_event.poll_logs(start_block=start_block, new_block_timeout=new_block_timeout)
+            self.provider.poll_logs(
+                start_block=start_block,
+                address=contract_address,
+                new_block_timeout=new_block_timeout,
+                events=[event_abi],
+            )
         ):
             await self._checkpoint(last_block_seen=event.block_number)
-            await self._handle_task(await event_handler.kiq(event))
+            await self._handle_task(await event_log_task_kicker.kiq(event))
             await self._checkpoint(last_block_processed=event.block_number)

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -5,6 +5,7 @@ from ape import chain
 from ape.logging import logger
 from ape.utils import ManagerAccessMixin
 from ape_ethereum.ecosystem import keccak
+from ethpm_types import EventABI
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
 from taskiq import AsyncTaskiqTask
@@ -301,8 +302,10 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
         if not (contract_address := task_data.labels.get("contract_address")):
             raise StartupFailure("Contract instance required.")
 
-        if not (event_abi := task_data.event_abi):
-            raise StartupFailure("No Event ABI provided.")
+        if not (event_signature := task_data.labels.get("event_signature")):
+            raise StartupFailure("No Event Signature provided.")
+
+        event_abi = EventABI.from_signature(event_signature)
 
         event_log_task_kicker = self._create_task_kicker(task_data)
 
@@ -368,8 +371,10 @@ class PollingRunner(BaseRunner, ManagerAccessMixin):
         if not (contract_address := task_data.labels.get("contract_address")):
             raise StartupFailure("Contract instance required.")
 
-        if not (event_abi := task_data.event_abi):
-            raise StartupFailure("No Event ABI provided.")
+        if not (event_signature := task_data.labels.get("event_signature")):
+            raise StartupFailure("No Event Signature provided.")
+
+        event_abi = EventABI.from_signature(event_signature)
 
         event_log_task_kicker = self._create_task_kicker(task_data)
         if address_settings := self.app.poll_settings.get(contract_address):

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -37,7 +37,6 @@ class Settings(BaseSettings, ManagerAccessMixin):
     SIGNER_ALIAS: str = ""
 
     NEW_BLOCK_TIMEOUT: int | None = None
-    START_BLOCK: int | None = None
 
     # Used for recorder
     RECORDER_CLASS: str | None = None

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -14,6 +14,7 @@ logger = get_logger(__name__)
 class TaskType(str, Enum):
     # System-only Tasks
     SYSTEM_CONFIG = "system:config"
+    SYSTEM_USER_TASKDATA = "system:user-taskdata"
 
     # User-accessible Tasks
     STARTUP = "startup"

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -17,10 +17,10 @@ class TaskType(str, Enum):
     SYSTEM_USER_TASKDATA = "system:user-taskdata"
 
     # User-accessible Tasks
-    STARTUP = "startup"
-    NEW_BLOCKS = "block"
-    EVENT_LOG = "event"
-    SHUTDOWN = "shutdown"
+    STARTUP = "user:startup"
+    NEW_BLOCK = "user:new-block"
+    EVENT_LOG = "user:event-log"
+    SHUTDOWN = "user:shutdown"
 
     def __str__(self) -> str:
         return self.value

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -12,6 +12,10 @@ logger = get_logger(__name__)
 
 
 class TaskType(str, Enum):
+    # System-only Tasks
+    SYSTEM_CONFIG = "system:config"
+
+    # User-accessible Tasks
     STARTUP = "startup"
     NEW_BLOCKS = "block"
     EVENT_LOG = "event"

--- a/silverback/utils.py
+++ b/silverback/utils.py
@@ -1,8 +1,23 @@
 import asyncio
 import threading
-from typing import AsyncIterator, Iterator
+from typing import AsyncIterator, Iterable, Iterator
 
 from ape.types import HexBytes
+from taskiq import AsyncTaskiqDecoratedTask, TaskiqResult
+
+
+async def run_taskiq_task_wait_result(
+    task_def: AsyncTaskiqDecoratedTask, *args, **kwargs
+) -> TaskiqResult:
+    task = await task_def.kiq(*args, **kwargs)
+    return await task.wait_result()
+
+
+async def run_taskiq_task_group_wait_results(
+    task_defs: Iterable[AsyncTaskiqDecoratedTask], *args, **kwargs
+) -> list[TaskiqResult]:
+    tasks = await asyncio.gather(*(task_def.kiq(*args, **kwargs) for task_def in task_defs))
+    return await asyncio.gather(*(task.wait_result() for task in tasks))
 
 
 def async_wrap_iter(it: Iterator) -> AsyncIterator:

--- a/silverback/utils.py
+++ b/silverback/utils.py
@@ -4,17 +4,18 @@ from typing import AsyncIterator, Iterable, Iterator
 
 from ape.types import HexBytes
 from taskiq import AsyncTaskiqDecoratedTask, TaskiqResult
+from taskiq.kicker import AsyncKicker
 
 
 async def run_taskiq_task_wait_result(
-    task_def: AsyncTaskiqDecoratedTask, *args, **kwargs
+    task_def: AsyncTaskiqDecoratedTask | AsyncKicker, *args, **kwargs
 ) -> TaskiqResult:
     task = await task_def.kiq(*args, **kwargs)
     return await task.wait_result()
 
 
 async def run_taskiq_task_group_wait_results(
-    task_defs: Iterable[AsyncTaskiqDecoratedTask], *args, **kwargs
+    task_defs: Iterable[AsyncTaskiqDecoratedTask | AsyncKicker], *args, **kwargs
 ) -> list[TaskiqResult]:
     tasks = await asyncio.gather(*(task_def.kiq(*args, **kwargs) for task_def in task_defs))
     return await asyncio.gather(*(task.wait_result() for task in tasks))


### PR DESCRIPTION
### What I did

This PR adds the concept of "system tasks" which will be a set of internal tasks that Runners can run to obtain metadata from a worker about the types of tasks it supports, the task data required to construct a message, and other information that is needed for the platform to reduce repetitive state communication and storage about bots

fixes: https://github.com/ApeWorX/silverback/issues/57

### How I did it

New tasks were added using the `system:` pre-pend to their task names in order to prevent conflicts with user-defined tasks (as they cannot contain a colon)

[cce2798](https://github.com/ApeWorX/silverback/pull/82/commits/cce27982f906f4fa81dcce84098af80c02f0dc04) adds the "system configuration task" which will return the SDK version of the worker and also the set of task types it supports. This will be useful when working with multiple versions of the SDK to determine whether you can support it (as shown by raising if the SDK is below a certain version) or by optionally executing features if the system/user task types are available to use

[d2bc419](https://github.com/ApeWorX/silverback/pull/82/commits/d2bc419adb46d87a878ca7a539cdffea95a18445) adds another system task that allows getting the task data necessary for a stateless runner to call the task by dynamically constructing an `AsyncKicker` object that can poke the broker in the way that will function both with `InMemoryBroker` and any other type of distributed broker that could be used (tested with Redis)

### How to verify it

Validate that the changes simplify the implementation downstream in the platform, and that no other errors were introduced

This will require a breaking change release, and updating [this](https://github.com/ApeWorX/silverback/pull/82/files#diff-051b8f597bfc50c9213c2a373c79fed3a7c836f3ae26ad51c3d994d91f7765e9R136) TODO prior to release of that breaking change update

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
