### PR TITLE
feat: adds task type SYSTEM_USER_ALL_TASKDATA

### DIFF
--- a/silverback/application.py
+++ b/silverback/application.py
@@ -140,7 +140,6 @@ class SilverbackApp(ManagerAccessMixin):
         return self.tasks.get(task_type, [])
 
     def __get_user_all_taskdata_handler(self) -> list[TaskData]:
-        # return {k: v for k, v in self.tasks.items() if str(k).startswith("user:")}
         return [v for k, l in self.tasks.items() if str(k).startswith("user:") for v in l]
 
     def broker_task_decorator(

--- a/silverback/application.py
+++ b/silverback/application.py
@@ -109,6 +109,9 @@ class SilverbackApp(ManagerAccessMixin):
         self._get_user_taskdata = self.__register_system_task(
             TaskType.SYSTEM_USER_TASKDATA, self.__get_user_taskdata_handler
         )
+        self._get_user_all_taskdata = self.__register_system_task(
+            TaskType.SYSTEM_USER_ALL_TASKDATA, self.__get_user_all_taskdata_handler
+        )
 
     def __register_system_task(
         self, task_type: TaskType, task_handler: Callable
@@ -135,6 +138,10 @@ class SilverbackApp(ManagerAccessMixin):
         # NOTE: This is actually executed on the worker side
         assert str(task_type).startswith("user:"), "Can only fetch user task data"
         return self.tasks.get(task_type, [])
+
+    def __get_user_all_taskdata_handler(self) -> list[TaskData]:
+        # return {k: v for k, v in self.tasks.items() if str(k).startswith("user:")}
+        return [v for k, l in self.tasks.items() if str(k).startswith("user:") for v in l]
 
     def broker_task_decorator(
         self,

--- a/silverback/types.py
+++ b/silverback/types.py
@@ -15,6 +15,7 @@ class TaskType(str, Enum):
     # System-only Tasks
     SYSTEM_CONFIG = "system:config"
     SYSTEM_USER_TASKDATA = "system:user-taskdata"
+    SYSTEM_USER_ALL_TASKDATA = "system:user-all-taskdata"
 
     # User-accessible Tasks
     STARTUP = "user:startup"


### PR DESCRIPTION
### What I did

Adds `TaskType.SYSTEM_USER_ALL_TASKDATA` to fetch all user defined tasks in one job.

![](https://media1.tenor.com/m/e_RofFmblEkAAAAC/me-think-kevin.gif)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
