### PR TITLE
feat: adds SILVERBACK_BROKER_KWARGS for broker config

### DIFF
--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -156,7 +156,7 @@ For this to work, you must configure a [TaskIQ broker](https://taskiq-python.git
 
 ```bash
 export SILVERBACK_BROKER_CLASS="taskiq_redis:ListQueueBroker"
-export SILVERBACK_BROKER_URI="redis://127.0.0.1:6379"
+export SILVERBACK_BROKER_KWARGS='{"queue_name": "taskiq", "url": "redis://127.0.0.1:6379"}'
 
 silverback run "example:app" \
     --network :mainnet:alchemy \
@@ -167,7 +167,7 @@ And then the worker process with 2 worker subprocesses:
 
 ```bash
 export SILVERBACK_BROKER_CLASS="taskiq_redis:ListQueueBroker"
-export SILVERBACK_BROKER_URI="redis://127.0.0.1:6379"
+export SILVERBACK_BROKER_KWARGS='{"url": "redis://127.0.0.1:6379"}'
 
 silverback worker -w 2 "example:app"
 ```

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -26,7 +26,8 @@ class Settings(BaseSettings, ManagerAccessMixin):
     APP_NAME: str = "bot"
 
     BROKER_CLASS: str = "taskiq:InMemoryBroker"
-    BROKER_URI: str = ""
+    BROKER_URI: str = ""  # to be deprecated in 0.6
+    BROKER_KWARGS: dict[str, Any] = dict()
 
     ENABLE_METRICS: bool = False
 
@@ -69,8 +70,13 @@ class Settings(BaseSettings, ManagerAccessMixin):
             broker = broker_class()
 
         else:
-            # TODO: Not all brokers share a common arg signature.
-            broker = broker_class(self.BROKER_URI or None)
+            # NOTE: BROKER_URI to be deprecated in 0.6
+            if self.BROKER_URI:
+                broker = broker_class(self.BROKER_URI or None)
+            elif self.BROKER_KWARGS:
+                broker = broker_class(**self.BROKER_KWARGS)
+            else:
+                broker = broker_class()
 
         if middlewares := self.get_middlewares():
             broker = broker.with_middlewares(*middlewares)

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from ape.api import AccountAPI, ProviderContextManager
 from ape.utils import ManagerAccessMixin
 from pydantic_settings import BaseSettings, SettingsConfigDict

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -72,13 +72,13 @@ class Settings(BaseSettings, ManagerAccessMixin):
             broker = broker_class()
 
         else:
-            # NOTE: BROKER_URI to be deprecated in 0.6
+            broker_kwargs = self.BROKER_KWARGS
+
             if self.BROKER_URI:
-                broker = broker_class(self.BROKER_URI or None)
-            elif self.BROKER_KWARGS:
-                broker = broker_class(**self.BROKER_KWARGS)
-            else:
-                broker = broker_class()
+                # TODO: Maybe add a deprecation warning here for v0.6
+                broker_kwargs["url"] = self.BROKER_URI
+
+            broker = broker_class(**broker_kwargs)
 
         if middlewares := self.get_middlewares():
             broker = broker.with_middlewares(*middlewares)


### PR DESCRIPTION
### What I did

Adds the `SILVERBACK_BROKER_KWARGS` for config to allow dynamic configuration of the broker.  

Change should be non-breaking, but we probably want to remove `BROKER_URI` in a future breaking release.

fixes: #85

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
