### PR TITLE
refactor: auto-select runner

### DIFF
--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -158,9 +158,7 @@ For this to work, you must configure a [TaskIQ broker](https://taskiq-python.git
 export SILVERBACK_BROKER_CLASS="taskiq_redis:ListQueueBroker"
 export SILVERBACK_BROKER_URI="redis://127.0.0.1:6379"
 
-silverback run "example:app" \
-    --network :mainnet:alchemy \
-    --runner "silverback.runner:WebsocketRunner"
+silverback run "example:app" --network :mainnet:alchemy
 ```
 
 And then the worker process with 2 worker subprocesses:


### PR DESCRIPTION
### What I did

With talking to @Ninjagod1251 realized we are in a position now (thanks to https://github.com/ApeWorX/ape/pull/1623) where we can just auto-select which runner to run with

### How I did it

### How to verify it

Unsure if we want to maintain backwards compatibility by allowing an override, but I can do that if needed

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
