### PR TITLE
refactor: add nonce tracking in TaskResult to index `app.signer` txns

### DIFF
--- a/silverback/recorder.py
+++ b/silverback/recorder.py
@@ -25,6 +25,7 @@ class TaskResult(BaseModel):
 
     # System Metrics here (must default to None in case they are missing)
     block_number: int | None = None
+    txns_by_nonce: list[int] = []
 
     # Custom user metrics here
     metrics: Datapoints
@@ -45,6 +46,9 @@ class TaskResult(BaseModel):
 
         if block_number := labels.get("block_number"):
             metrics["block_number"] = int(block_number)
+
+        if txns_by_nonce := labels.get("txns_by_nonce"):
+            metrics["txns_by_nonce"] = txns_by_nonce
 
         return metrics
 


### PR DESCRIPTION
### What I did

Added nonce tracking logic into `SilverbackMiddleware`, which updates a label in `.post_execute` that gets stored in `TaskResult`. If you know the account address, you can do additional parsing post-task (assuming that the transaction has been finalized) to obtain the transaction receipt information from this combination.

fixes: #88
fixes SBK-463

### How I did it

Realized that `SilverbackSettings` was already passing itself to `SIlverbackMiddleware`

### How to verify it

I ran the example app with `--account <My wallet>` and then separately sent a transaction from that wallet address in `ape console`

In production, it will be strongly suggested to never mix keys like this as it is not a good idea anyways (due to requirement for stateful nonce tracking), but it will also give you a false positive of what transactions occured in the task.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
