### PR TITLE
feat: adds Web3SubscriptionsManager.get_subscription_data_nowait()

### DIFF
--- a/silverback/subscriptions.py
+++ b/silverback/subscriptions.py
@@ -155,23 +155,6 @@ class Web3SubscriptionsManager:
                 except asyncio.QueueEmpty:
                     pass
 
-    async def pop_subscription_data(self, sub_id: str) -> Union[dict, None]:
-        """Remove and return a single item from the subscription queue."""
-
-        async with self._ws_lock:
-            # NOTE: Python <3.10 does not support `anext` function
-            await self.__anext__()
-
-        queue = self._subscriptions.get(sub_id)
-
-        if queue:
-            try:
-                return queue.get_nowait()
-            except asyncio.QueueEmpty:
-                pass
-
-        return None
-
     async def unsubscribe(self, sub_id: str) -> bool:
         if sub_id not in self._subscriptions:
             raise ValueError(f"Unknown sub_id '{sub_id}'")

--- a/silverback/subscriptions.py
+++ b/silverback/subscriptions.py
@@ -55,9 +55,8 @@ class Web3SubscriptionsManager:
         if not self.connection:
             raise ConnectionError("Connection not opened")
 
-        async with asyncio.timeout(timeout):
-            message = await self.connection.recv()
-            # TODO: Handle retries when connection breaks
+        message = await asyncio.wait_for(self.connection.recv(), timeout)
+        # TODO: Handle retries when connection breaks
 
         response = json.loads(message)
         if response.get("method") == "eth_subscription":

--- a/silverback/subscriptions.py
+++ b/silverback/subscriptions.py
@@ -139,7 +139,7 @@ class Web3SubscriptionsManager:
                     await self.__anext__()
             else:
                 try:
-                    yield await queue.get_nowait()
+                    yield queue.get_nowait()
                 except asyncio.QueueEmpty:
                     pass
 
@@ -154,7 +154,7 @@ class Web3SubscriptionsManager:
 
         if queue:
             try:
-                return await queue.get_nowait()
+                return queue.get_nowait()
             except asyncio.QueueEmpty:
                 pass
 

--- a/silverback/subscriptions.py
+++ b/silverback/subscriptions.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 from enum import Enum
-from typing import AsyncGenerator, Union
+from typing import AsyncGenerator, Optional, Union
 
 from ape.logging import logger
 from websockets import ConnectionClosedError
@@ -46,14 +46,14 @@ class Web3SubscriptionsManager:
         if not self.connection:
             raise StopAsyncIteration
 
-        return self._receive()
+        return await self._receive()
 
     async def _receive(self, timeout: Optional[int] = None) -> str:
         """Receive (and wait if no timeout) for the next message from the
         socket.
         """
         if not self.connection:
-            raise ConnectionClosedError()
+            raise ConnectionError("Connection not opened")
 
         async with asyncio.timeout(timeout):
             message = await self.connection.recv()

--- a/silverback/subscriptions.py
+++ b/silverback/subscriptions.py
@@ -144,23 +144,16 @@ class Web3SubscriptionsManager:
         """
         while True:
             if not (queue := self._subscriptions.get(sub_id)) or queue.empty():
-                logger.debug(
-                    f"Acquiring lock for recv (no wait). (is locked? {self._ws_lock.locked()})"
-                )
                 async with self._ws_lock:
-                    logger.debug("Acquired lock for recv (no wait).")
                     try:
                         await self._receive(timeout=timeout)
                     except TimeoutError:
                         logger.debug("Receive call timed out.")
                         return
-                    else:
-                        logger.debug("Receive call completed.")
             else:
                 try:
                     yield queue.get_nowait()
                 except asyncio.QueueEmpty:
-                    logger.debug("Subscription queue empty.")
                     return
 
     async def unsubscribe(self, sub_id: str) -> bool:

--- a/silverback/subscriptions.py
+++ b/silverback/subscriptions.py
@@ -144,10 +144,11 @@ class Web3SubscriptionsManager:
         """
         while True:
             if not (queue := self._subscriptions.get(sub_id)) or queue.empty():
-                try:
-                    await self._receive(timeout=timeout)
-                except TimeoutError:
-                    pass
+                async with self._ws_lock:
+                    try:
+                        await self._receive(timeout=timeout)
+                    except TimeoutError:
+                        pass
             else:
                 try:
                     yield queue.get_nowait()


### PR DESCRIPTION
### What I did

Adds `Web3SubscriptionsManager.get_subscription_data_nowait()` to add the ability to poll without a hanging iterator.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
