### PR TITLE
feat: adds RESULT_BACKEND_KWARGS to settings

### DIFF
--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -28,13 +28,13 @@ class Settings(BaseSettings, ManagerAccessMixin):
     APP_NAME: str = "bot"
 
     BROKER_CLASS: str = "taskiq:InMemoryBroker"
-    BROKER_URI: str = ""  # to be deprecated in 0.6
+    BROKER_URI: str = ""  # To be deprecated in 0.6
     BROKER_KWARGS: dict[str, Any] = dict()
 
     ENABLE_METRICS: bool = False
 
     RESULT_BACKEND_CLASS: str = ""
-    RESULT_BACKEND_URI: str = ""  # to be deprecated in 0.6
+    RESULT_BACKEND_URI: str = ""  # To be deprecated in 0.6
     RESULT_BACKEND_KWARGS: str = ""
 
     NETWORK_CHOICE: str = ""

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -34,7 +34,8 @@ class Settings(BaseSettings, ManagerAccessMixin):
     ENABLE_METRICS: bool = False
 
     RESULT_BACKEND_CLASS: str = ""
-    RESULT_BACKEND_URI: str = ""
+    RESULT_BACKEND_URI: str = ""  # to be deprecated in 0.6
+    RESULT_BACKEND_KWARGS: str = ""
 
     NETWORK_CHOICE: str = ""
     SIGNER_ALIAS: str = ""
@@ -60,11 +61,17 @@ class Settings(BaseSettings, ManagerAccessMixin):
         return middlewares
 
     def get_result_backend(self) -> AsyncResultBackend | None:
-        if not (backend_cls_str := self.RESULT_BACKEND_CLASS):
+        if self.RESULT_BACKEND_CLASS:
             return None
 
-        result_backend_cls = import_from_string(backend_cls_str)
-        return result_backend_cls(self.RESULT_BACKEND_URI)
+        result_backend_cls = import_from_string(self.RESULT_BACKEND_CLASS)
+
+        if self.RESULT_BACKEND_URI:
+            # TODO: Maybe add a deprecation warning here for v0.6
+            return result_backend_cls(self.RESULT_BACKEND_URI)
+
+        backend_kwargs = self.RESULT_BACKEND_KWARGS
+        return result_backend_cls(**backend_kwargs)
 
     def get_broker(self) -> AsyncBroker:
         broker_class = import_from_string(self.BROKER_CLASS)

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -61,7 +61,7 @@ class Settings(BaseSettings, ManagerAccessMixin):
         return middlewares
 
     def get_result_backend(self) -> AsyncResultBackend | None:
-        if self.RESULT_BACKEND_CLASS:
+        if not self.RESULT_BACKEND_CLASS:
             return None
 
         result_backend_cls = import_from_string(self.RESULT_BACKEND_CLASS)


### PR DESCRIPTION
### What I did

Adds `RESULT_BACKEND_KWARGS` to settings to allow more dynamic configuration of the result backend.

### Checklist

- [X] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [X] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
