### PR TITLE
feat: unlock acct for auto-signing if alias resolves to KeyfileAccount

### DIFF
--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -120,6 +120,16 @@ def handle_on_shutdown():
 
 *Changed in 0.2.0*: The behavior of the `@app.on_startup()` decorator and handler signature have changed.  It is now executed only once upon application startup and worker events have moved on `@app.on_worker_startup()`.
 
+### Signing Transactions
+
+If configured, your bot with have `app.signer` which is an Ape account that can sign arbitrary transactions you ask it to.
+To learn more about signing transactions with Ape, see the [documentation](https://docs.apeworx.io/ape/stable/userguides/transactions.html).
+
+```{warning}
+While not recommended, you can use keyfile accounts for automated signing.
+See [this guide](https://docs.apeworx.io/ape/stable/userguides/accounts.html#automation) to learn more about how to do that.
+```
+
 ## Running your Application
 
 Once you have programmed your bot, it's really useful to be able to run it locally and validate that it does what you expect it to do.
@@ -141,9 +151,14 @@ else:
     # Log what the transaction *would* have done, had a signer been enabled
 ```
 
-```{note}
+```{warning}
 If you configure your application to use a signer, and that signer signs anything given to it, remember that you can lose substational amounts of funds if you deploy this to a production network.
-Always test your applications throughly before deploying.
+Always test your applications throughly before deploying, and always use a dedicated key for production signing with your application in a remote setting.
+```
+
+```{note}
+It is highly suggested to use a dedicated cloud signer plugin, such as [`ape-aws`](https://github.com/ApeWorX/ape-aws) for signing transactions in a cloud environment.
+Use segregated keys and limit your risk by controlling the amount of funds that key has access to at any given time.
 ```
 
 ### Distributed Execution

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from ape.api import AccountAPI, ProviderContextManager
 from ape.utils import ManagerAccessMixin
+from ape_accounts import KeyfileAccount
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from taskiq import (
     AsyncBroker,
@@ -122,4 +123,10 @@ class Settings(BaseSettings, ManagerAccessMixin):
             return self.account_manager.test_accounts[acct_idx]
 
         # NOTE: Will only have a signer if assigned one here (or in app)
-        return self.account_manager.load(alias)
+        signer = self.account_manager.load(alias)
+
+        # NOTE: Set autosign if it's a keyfile account (for local testing)
+        if isinstance(signer, KeyfileAccount):
+            signer.set_autosign(True)
+
+        return signer


### PR DESCRIPTION
### What I did

This PR add a small UX enhancement where `acct.set_autosign(True)` is automatically called if a `KeyfileAccount` is provided for the alias. This will assist testing in local scenarios for rapid prototyping with a local wallet.

fixes: #90 

### How to verify it

```sh
$ silverback run example:app --network ethereum:mainnet
...  # runs just fine without a signer

$ silverback run example:app --network ethereum:mainnet --account <my-keyfile-alias>
INFO: Loading Silverback App with settings:
  APP_NAME="bot"
  ...
Enter passphrase to permanently unlock 'my-keyfile-alias':
WARNING: Danger! This account will now sign any transaction it's given.
SUCCESS: Loaded Silverback App:
  NETWORK="ethereum:mainnet"
  SIGNER=<KeyfileAccount address=0x...  alias=dev >
INFO: Using WebsocketRunner: max_exceptions=3
...
```

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
