### PR TITLE
fix: wrong type on RESULT_BACKEND_KWARGS

### DIFF
--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -35,7 +35,7 @@ class Settings(BaseSettings, ManagerAccessMixin):
 
     RESULT_BACKEND_CLASS: str = ""
     RESULT_BACKEND_URI: str = ""  # To be deprecated in 0.6
-    RESULT_BACKEND_KWARGS: str = ""
+    RESULT_BACKEND_KWARGS: dict[str, Any] = dict()
 
     NETWORK_CHOICE: str = ""
     SIGNER_ALIAS: str = ""


### PR DESCRIPTION
### What I did

Fixed a bad type on settings from PR #96 

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
