### PR TITLE
fix: handle deserialization of TaskResult

### DIFF
--- a/silverback/types.py
+++ b/silverback/types.py
@@ -80,7 +80,12 @@ class Datapoints(RootModel):
         names_to_remove: dict[str, ValidationError] = {}
         # Automatically convert raw scalar types
         for name in datapoints:
-            if not isinstance(datapoints[name], Datapoint):
+            if isinstance(datapoints[name], dict) and "type" in datapoints[name]:
+                try:
+                    datapoints[name] = ScalarDatapoint.model_validate(datapoints[name])
+                except ValidationError as e:
+                    names_to_remove[name] = e
+            elif not isinstance(datapoints[name], Datapoint):
                 try:
                     datapoints[name] = ScalarDatapoint(data=datapoints[name])
                 except ValidationError as e:


### PR DESCRIPTION
### What I did

Handles deserialization of TaskResult.

fixes: #107

### How I did it

`ScalarDatapoint` may be in dict form.

### How to verify it

```python
>>> from silverback.types import Datapoints
>>> from taskiq import TaskiqResult
>>> from silverback.recorder import TaskResult
>>> from silverback_cluster_common.types import InstancedTaskResult
>>> result = TaskResult.from_taskiq(TaskiqResult(is_err=False, log=None, return_value={'foo': 123, 'value': 0.01}, execution_time=0.39, labels={}, error=None))
>>> TaskResult.model_validate(result.model_dump())
TaskResult(task_name='handle_transfer', execution_time=0.39, error=None, completed=datetime.datetime(2024, 8, 9, 3, 26, 39, 738962, tzinfo=TzInfo(UTC)), block_number=6464337, metrics=Datapoints(root={'foo': ScalarDatapoint(type='scalar', data=123), 'value': ScalarDatapoint(type='scalar', data=0.01)}))
>>> 
```

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
