### PR TITLE
test: max type was off in the test

### DIFF
--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -19,8 +19,8 @@ from silverback.types import Datapoints
         ),
         # int over INT96 max parses as Decimal
         (
-            {"a": 2**96},
-            {"a": {"type": "scalar", "data": Decimal("79228162514264337593543950336")}},
+            {"a": 2**95},
+            {"a": {"type": "scalar", "data": Decimal("39614081257132168796771975168")}},
         ),
         # Decimal parses as Decimal
         (

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -14,8 +14,8 @@ from silverback.types import Datapoints
         ({"a": 1}, {"a": {"type": "scalar", "data": 1}}),
         # max INT96 value
         (
-            {"a": 2**96 - 1},
-            {"a": {"type": "scalar", "data": 79228162514264337593543950335}},
+            {"a": 2**95 - 1},
+            {"a": {"type": "scalar", "data": 39614081257132168796771975167}},
         ),
         # int over INT96 max parses as Decimal
         (


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #113 

### How I did it

The max int for Int96 is defined as `2**95 - 1` but the test was using `2**96 - 1`

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
