### PR TITLE
feat(cli)!: find bots by default paths

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -66,7 +66,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            BASE_APE_IMAGE_TAG=latest
+            BASE_APE_IMAGE_TAG=stable
 
       - name: Fetch all tags and store them
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,7 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=tag
             type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            type=ref,event=tag
             type=ref,event=pr
 
       - name: Show tags
@@ -65,7 +66,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            BASE_APE_IMAGE_TAG=latest-slim
+            BASE_APE_IMAGE_TAG=latest
 
       - name: Fetch all tags and store them
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,13 @@ RUN pip wheel . --wheel-dir=/wheels
 FROM ghcr.io/apeworx/ape:${BASE_APE_IMAGE_TAG:-latest-slim}
 USER root
 COPY --from=builder /wheels /wheels
-RUN pip install asyncer 'taskiq-sqs>=0.0.11' ape-alchemy ape-etherscan
 RUN pip install --upgrade pip \
-    && pip install silverback --no-cache-dir --find-links=/wheels 
+    && pip install silverback \
+    asyncer \
+    'taskiq-sqs>=0.0.11' \
+    ape-alchemy \
+    ape-etherscan \
+    --no-cache-dir --find-links=/wheels
 USER harambe
 
 ENTRYPOINT ["silverback"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ USER root
 COPY --from=builder /wheels /wheels
 RUN pip install --upgrade pip \
     && pip install silverback \
-    asyncer \
     'taskiq-sqs>=0.0.11' \
     --no-cache-dir --find-links=/wheels
 USER harambe

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN pip install --upgrade pip && pip install wheel
 RUN pip wheel . --wheel-dir=/wheels
 
 # Install from wheels
-FROM ghcr.io/apeworx/ape:${BASE_APE_IMAGE_TAG:-latest-slim}
+FROM ghcr.io/apeworx/ape:${BASE_APE_IMAGE_TAG:-latest}
 USER root
 COPY --from=builder /wheels /wheels
 RUN pip install --upgrade pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ RUN pip install --upgrade pip \
     && pip install silverback \
     asyncer \
     'taskiq-sqs>=0.0.11' \
-    ape-alchemy \
-    ape-etherscan \
     --no-cache-dir --find-links=/wheels
 USER harambe
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,14 @@ If you want to learn more about what that means, please visit the [development u
 ```{note}
 It is suggested that you create a bots/ folder in the root of your project.
 Silverback will automatically register files in this folder as separate bots that can be run via the `silverback run` command.
+```
 
+```{note}
 It is also suggested that you treat this as a scripts folder, and do not include an __init__.py
 If you have a complicated project, follow the previous example to ensure you run the application correctly.
+```
 
+```{note}
 A final suggestion would be to name your `SilverbackApp` object `bot`. Silverback automatically searches 
 for this object name when running. If you do not do so, once again, ensure you replace `example` with 
 `example:<name-of-object>` the previous example.
@@ -83,7 +87,7 @@ To auto-generate Dockerfiles for your bots, from the root of your project, you c
 silverback build
 ```
 
-This will place your dockerfiles in the root of your project.
+This will place the generated dockerfiles in a special directory in the root of your project.
 
 As an example, if you have a bots directory that looks like:
 
@@ -97,12 +101,13 @@ bots/
 This method will generate 3 Dockerfiles:
 
 ```
+.silverback-images/
 ├── Dockerfile.botA
 ├── Dockerfile.botB
 ├── Dockerfile.botC
 ```
 
-These Dockerfiles can be deployed with the `docker run` command documented in the next section.
+These Dockerfiles can be deployed with the `docker push` command documented in the next section so you can use it in cloud-based deployments.
 
 ```{note}
 As an aside, if your bots/ directory is a python package, you will cause conflicts with the dockerfile generation feature. This method will warn you that you are generating bots for a python package, but will not stop you from doing so. If you choose to generate dockerfiles, the user should be aware that it will only copy each individual file into the Dockerfile, and will not include any supporting python functionality. Each python file is expected to run independently. If you require more complex bots, you will have to build a custom docker image.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Be sure to properly configure your environment for the USDC and YFI tokens on Et
 To run your bot against a live network, this SDK includes a simple runner command you can use via:
 
 ```sh
-$ silverback run "example" --network :mainnet:alchemy
+$ silverback run example --network :mainnet:alchemy
 ```
 
 ```{note}
@@ -80,7 +80,7 @@ for this object name when running. If you do not do so, once again, ensure you r
 ## Docker Usage
 
 ```sh
-$ docker run --volume $PWD:/home/harambe/project --volume ~/.tokenlists:/home/harambe/.tokenlists apeworx/silverback:latest run "example" --network :mainnet
+$ docker run --volume $PWD:/home/harambe/project --volume ~/.tokenlists:/home/harambe/.tokenlists apeworx/silverback:latest run example --network :mainnet
 ```
 
 ```{note}
@@ -97,7 +97,7 @@ If you want to use a hosted provider with websocket support like Alchemy to run 
 If you attempt to run the `Docker Usage` command without supplying this key, you will get the following error:
 
 ```bash
-$ docker run --volume $PWD:/home/harambe/project --volume ~/.tokenlists:/home/harambe/.tokenlists apeworx/silverback:latest run "example" --network :mainnet:alchemy
+$ docker run --volume $PWD:/home/harambe/project --volume ~/.tokenlists:/home/harambe/.tokenlists apeworx/silverback:latest run example --network :mainnet:alchemy
 Traceback (most recent call last):
   ...
 ape_alchemy.exceptions.MissingProjectKeyError: Must set one of $WEB3_ALCHEMY_PROJECT_ID, $WEB3_ALCHEMY_API_KEY, $WEB3_ETHEREUM_MAINNET_ALCHEMY_PROJECT_ID, $WEB3_ETHEREUM_MAINNET_ALCHEMY_API_KEY.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ This method will generate 3 Dockerfiles:
 
 These Dockerfiles can be deployed with the `docker run` command documented in the next section.
 
+```{note}
+As an aside, if your bots/ directory is a python package, you will cause conflicts with the dockerfile generation feature. This method will warn you that you are generating runners for a python package, but will not stop you from doing so. If you choose to generate dockerfiles, the user should be aware that it will only copy each individual file into the Dockerfile, and will not include any supporting python functionality. Each python file is expected to run independently. If you require more complex runners, you will have to build a custom docker image.
+```
+
 ## Docker Usage
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Be sure to properly configure your environment for the USDC and YFI tokens on Et
 To run your bot against a live network, this SDK includes a simple runner command you can use via:
 
 ```sh
-$ silverback run "example:bot" --network :mainnet:alchemy
+$ silverback run "example" --network :mainnet:alchemy
 ```
 
 ```{note}
@@ -66,21 +66,21 @@ If you want to learn more about what that means, please visit the [development u
 ```
 
 ```{note}
-It is suggested that you create a bots/ folder in the root of your project. All project files that 
-are going to be ran will reside in this folder.
+It is suggested that you create a bots/ folder in the root of your project.
+Silverback will automatically register files in this folder as separate bots that can be run via the `silverback run` command.
 
 It is also suggested that you treat this as a scripts folder, and do not include an __init__.py
 If you have a complicated project, follow the previous example to ensure you run the application correctly.
 
 A final suggestion would be to name your `SilverbackApp` object `bot`. Silverback automatically searches 
-for this object name when running. If you do not do so, once again, ensure you replace `example:bot` with 
+for this object name when running. If you do not do so, once again, ensure you replace `example` with 
 `example:<name-of-object>` the previous example.
 ```
 
 ## Docker Usage
 
 ```sh
-$ docker run --volume $PWD:/home/harambe/project --volume ~/.tokenlists:/home/harambe/.tokenlists apeworx/silverback:latest run "example:bot" --network :mainnet
+$ docker run --volume $PWD:/home/harambe/project --volume ~/.tokenlists:/home/harambe/.tokenlists apeworx/silverback:latest run "example" --network :mainnet
 ```
 
 ```{note}
@@ -97,7 +97,7 @@ If you want to use a hosted provider with websocket support like Alchemy to run 
 If you attempt to run the `Docker Usage` command without supplying this key, you will get the following error:
 
 ```bash
-$ docker run --volume $PWD:/home/harambe/project --volume ~/.tokenlists:/home/harambe/.tokenlists apeworx/silverback:latest run "example:bot" --network :mainnet:alchemy
+$ docker run --volume $PWD:/home/harambe/project --volume ~/.tokenlists:/home/harambe/.tokenlists apeworx/silverback:latest run "example" --network :mainnet:alchemy
 Traceback (most recent call last):
   ...
 ape_alchemy.exceptions.MissingProjectKeyError: Must set one of $WEB3_ALCHEMY_PROJECT_ID, $WEB3_ALCHEMY_API_KEY, $WEB3_ETHEREUM_MAINNET_ALCHEMY_PROJECT_ID, $WEB3_ETHEREUM_MAINNET_ALCHEMY_API_KEY.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ for this object name when running. If you do not do so, once again, ensure you r
 To auto-generate Dockerfiles for your bots, from the root of your project, you can run:
 
 ```bash
-silverback generate-dockerfiles
+silverback build
 ```
 
 This will place your dockerfiles in the root of your project.

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ The example makes use of the [Ape Tokens](https://github.com/ApeWorX/ape-tokens)
 Be sure to properly configure your environment for the USDC and YFI tokens on Ethereum mainnet.
 ```
 
-To run your bot against a live network, this SDK includes a simple runner command you can use via:
+To run your bot against a live network, this SDK includes a simple bot command you can use via:
 
 ```sh
 $ silverback run example --network :mainnet:alchemy
 ```
 
 ```{note}
-This runner uses an in-memory task broker by default.
+This bot uses an in-memory task broker by default.
 If you want to learn more about what that means, please visit the [development userguide](https://docs.apeworx.io/silverback/stable/userguides/development.html).
 ```
 
@@ -105,7 +105,7 @@ This method will generate 3 Dockerfiles:
 These Dockerfiles can be deployed with the `docker run` command documented in the next section.
 
 ```{note}
-As an aside, if your bots/ directory is a python package, you will cause conflicts with the dockerfile generation feature. This method will warn you that you are generating runners for a python package, but will not stop you from doing so. If you choose to generate dockerfiles, the user should be aware that it will only copy each individual file into the Dockerfile, and will not include any supporting python functionality. Each python file is expected to run independently. If you require more complex runners, you will have to build a custom docker image.
+As an aside, if your bots/ directory is a python package, you will cause conflicts with the dockerfile generation feature. This method will warn you that you are generating bots for a python package, but will not stop you from doing so. If you choose to generate dockerfiles, the user should be aware that it will only copy each individual file into the Dockerfile, and will not include any supporting python functionality. Each python file is expected to run independently. If you require more complex bots, you will have to build a custom docker image.
 ```
 
 ## Docker Usage

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Be sure to properly configure your environment for the USDC and YFI tokens on Et
 To run your bot against a live network, this SDK includes a simple runner command you can use via:
 
 ```sh
-$ silverback run "example:app" --network :mainnet:alchemy
+$ silverback run "example:bot" --network :mainnet:alchemy
 ```
 
 ```{note}
@@ -65,10 +65,22 @@ This runner uses an in-memory task broker by default.
 If you want to learn more about what that means, please visit the [development userguide](https://docs.apeworx.io/silverback/stable/userguides/development.html).
 ```
 
+```{note}
+It is suggested that you create a bots/ folder in the root of your project. All project files that 
+are going to be ran will reside in this folder.
+
+It is also suggested that you treat this as a scripts folder, and do not include an __init__.py
+If you have a complicated project, follow the previous example to ensure you run the application correctly.
+
+A final suggestion would be to name your `SilverbackApp` object `bot`. Silverback automatically searches 
+for this object name when running. If you do not do so, once again, ensure you replace `example:bot` with 
+`example:<name-of-object>` the previous example.
+```
+
 ## Docker Usage
 
 ```sh
-$ docker run --volume $PWD:/home/harambe/project --volume ~/.tokenlists:/home/harambe/.tokenlists apeworx/silverback:latest run "example:app" --network :mainnet
+$ docker run --volume $PWD:/home/harambe/project --volume ~/.tokenlists:/home/harambe/.tokenlists apeworx/silverback:latest run "example:bot" --network :mainnet
 ```
 
 ```{note}
@@ -85,7 +97,7 @@ If you want to use a hosted provider with websocket support like Alchemy to run 
 If you attempt to run the `Docker Usage` command without supplying this key, you will get the following error:
 
 ```bash
-$ docker run --volume $PWD:/home/harambe/project --volume ~/.tokenlists:/home/harambe/.tokenlists apeworx/silverback:latest run "example:app" --network :mainnet:alchemy
+$ docker run --volume $PWD:/home/harambe/project --volume ~/.tokenlists:/home/harambe/.tokenlists apeworx/silverback:latest run "example:bot" --network :mainnet:alchemy
 Traceback (most recent call last):
   ...
 ape_alchemy.exceptions.MissingProjectKeyError: Must set one of $WEB3_ALCHEMY_PROJECT_ID, $WEB3_ALCHEMY_API_KEY, $WEB3_ETHEREUM_MAINNET_ALCHEMY_PROJECT_ID, $WEB3_ETHEREUM_MAINNET_ALCHEMY_API_KEY.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,33 @@ for this object name when running. If you do not do so, once again, ensure you r
 `example:<name-of-object>` the previous example.
 ```
 
+To auto-generate Dockerfiles for your bots, from the root of your project, you can run:
+
+```bash
+silverback generate-dockerfiles
+```
+
+This will place your dockerfiles in the root of your project.
+
+As an example, if you have a bots directory that looks like:
+
+```
+bots/
+├── botA.py
+├── botB.py
+├── botC.py
+```
+
+This method will generate 3 Dockerfiles:
+
+```
+├── Dockerfile.botA
+├── Dockerfile.botB
+├── Dockerfile.botC
+```
+
+These Dockerfiles can be deployed with the `docker run` command documented in the next section.
+
 ## Docker Usage
 
 ```sh

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -14,27 +14,28 @@ It if finds a module named `bot.py` either in the `bots/` directory or at the ro
 It will also be able to detect the scripts inside your `bots/` directory and let you run those by name (in case you have multiple bots in your project).
 It is suggested that you create the instance of your `SilverbackApp()` object by naming the variable `bot`, since `silverback` will autodetect that variable name when loading your script file.
 
-If you have a more complicated project that requires multiple bots, naming each bot their own individual name is okay to do. It is still suggested that you name the variable that instantiates the application (`SilverbackApp()`) `bot`. An example is shown in the next section of this page.
+If you have a more complicated project that requires multiple bots, naming each bot their own individual name is okay to do, and we encourage you to locate them under the `bots/` folder relative to the root of your project.
+This will work fairly seamless with the rest of the examples shown in this guide.
 
-To run the application, as long as your project directory follows the suggestion here, you can run it with:
+To run a bot, as long as your project directory follows the suggestion above by using a `bot.py` script, you can run it easily with:
 
 ```bash
 silverback run --network your:network:of:choice
 ```
 
-If your bot's module name is not `bot.py`:
+However, if your bot's module name is not `bot.py` but `example.py` (for example), you can run it like this:
 
 ```bash
 silverback run example --network your:network:of:choice
 ```
 
-If you instantiate your `SilverbackApp()` object with something other than `bot`:
+If the variable that you call the `SilverbackApp()` object is something other than `bot`, you can specific that by adding `:{variable name}`:
 
 ```bash
 silverback run example:app --network your:network:of:choice
 ```
 
-And if your bot resides in a location other than `bots/` or the root of the project:
+We will automatically detect all scripts under the `bots/` folder automatically, but if your bot resides in a location other than `bots/` then you can use this to run it:
 
 ```bash
 silverback run folder.example:app --network your:network:of:choice
@@ -174,11 +175,11 @@ To run your bot locally, we have included a really useful cli command [`run`](..
 
 ```sh
 # Run your bot on the Ethereum Sepolia testnet, with your own signer:
-$ silverback run my_bot:bot --network :sepolia --account acct-name
+$ silverback run my_bot --network :sepolia --account acct-name
 ```
 
 ```{note}
-`my_bot:bot` is not required for silverback run if you follow the suggested folder structure at the start of this page.
+`my_bot:bot` is not required for silverback run if you follow the suggested folder structure at the start of this page, you can just call it via `my_bot`.
 ```
 
 It's important to note that signers are optional, if not configured in the application then `bot.signer` will be `None`.

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -9,11 +9,11 @@ You can install Silverback via `pip install silverback`
 
 ## Project structure
 
-There are 3 suggested ways to structure your project:
+There are 3 suggested ways to structure your project. In the root directory of your project:
 
-1. Create a `bot.py` file in the root directory of your project. This is the simplest way to define your bot project.
+1. Create a `bot.py` file. This is the simplest way to define your bot project.
 
-2. Create a `bots/` folder in the root directory of your project. Then develop bots in this folder as separate scripts (Do not include a __init__.py file).
+2. Create a `bots/` folder. Then develop bots in this folder as separate scripts (Do not include a __init__.py file).
 
 3. Create a `bot/` folder with a `__init__.py` file that will include the instantiation of your `SilverbackApp()` object.
 

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -55,7 +55,7 @@ We will automatically detect all scripts under the `bots/` folder automatically,
 silverback run folder.example:app --network your:network:of:choice
 ```
 
-With a `bot/__init__.py` setup, you can run with:
+Note that with a `bot/__init__.py` setup, silverback will also autodetect it, and you can run it with:
 
 ```bash
 silverback run --network your:network:of:choice

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -58,7 +58,7 @@ silverback run folder.example:app --network your:network:of:choice
 With a `bot/__init__.py` setup, you can run with:
 
 ```bash
-silverback run bot --network your:network:of:choice
+silverback run --network your:network:of:choice
 ```
 
 ```{note}

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -31,6 +31,12 @@ Another way you can structure your bot is to create a `bot` folder and define a 
 If you have a more complicated project that requires multiple bots, naming each bot their own individual name is okay to do, and we encourage you to locate them under the `bots/` folder relative to the root of your project.
 This will work fairly seamlessly with the rest of the examples shown in this guide.
 
+To run a bot, as long as your project directory follows the suggestions above by using a `bot` module, you can run it easily with:
+
+```bash
+silverback run --network your:network:of:choice
+```
+
 If your bot's module name is `example.py` (for example), you can run it like this:
 
 ```bash

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -46,7 +46,7 @@ silverback run example --network your:network:of:choice
 If the variable that you call the `SilverbackApp()` object is something other than `bot`, you can specific that by adding `:{variable-name}`:
 
 ```bash
-silverback run example:{variable-name} --network your:network:of:choice
+silverback run example:my_bot --network your:network:of:choice
 ```
 
 We will automatically detect all scripts under the `bots/` folder automatically, but if your bot resides in a location other than `bots/` then you can use this to run it:

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -29,7 +29,7 @@ It is suggested that you create the instance of your `SilverbackApp()` object by
 Another way you can structure your bot is to create a `bot` folder and define a runner inside of that folder as `__init__.py`.
 
 If you have a more complicated project that requires multiple bots, naming each bot their own individual name is okay to do, and we encourage you to locate them under the `bots/` folder relative to the root of your project.
-This will work fairly seamless with the rest of the examples shown in this guide.
+This will work fairly seamlessly with the rest of the examples shown in this guide.
 
 If your bot's module name is `example.py` (for example), you can run it like this:
 

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -21,6 +21,8 @@ The `silverback` cli automatically searches for python scripts to run as bots in
 It will also be able to detect the scripts inside your `bots/` directory and let you run those by name (in case you have multiple bots in your project).
 `silverback` can also deal with a `bot/` folder with an `__init__.py` file that is defined as the runner.
 
+If `silverback` finds a module named `bot` in the root directory of the project, then it will use that by default.
+
 ```{note}
 It is suggested that you create the instance of your `SilverbackApp()` object by naming the variable `bot`, since `silverback` will autodetect that variable name when loading your script file.
 ```

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -9,7 +9,10 @@ You can install Silverback via `pip install silverback`
 
 ## Project structure
 
-The `silverback` cli automatically searches for python scripts in the `bots/` directory at the root of your project. It will also automatically search for a `bot.py` module in either the `bots/` directory or at the root directory of the project. It is also suggested that you instantiate your `SilverbackApp()` object by naming the variable `bot`, since `silverback` autodetects that variable name in your bot.
+The `silverback` cli automatically searches for python scripts to run as bots in specific locations relative to the root of your project.
+It if finds a module named `bot.py` either in the `bots/` directory or at the root directory of the project, then it will use that by default.
+It will also be able to detect the scripts inside your `bots/` directory and let you run those by name (in case you have multiple bots in your project).
+It is suggested that you create the instance of your `SilverbackApp()` object by naming the variable `bot`, since `silverback` will autodetect that variable name when loading your script file.
 
 If you have a more complicated project that requires multiple bots, naming each bot their own individual name is okay to do. It is still suggested that you name the variable that instantiates the application (`SilverbackApp()`) `bot`. An example is shown in the next section of this page.
 

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -62,7 +62,11 @@ silverback run --network your:network:of:choice
 ```
 
 ```{note}
-It is suggested that you develop your modules as scripts to keep your deployments simple. If you have a deep understanding of containerization, and distributed applications, you can set your bots up however you'd like, and then create your own container definitions for deployments. For a simple deployment ecosystem, develop your bots as scripts, and avoid developing your applications as packages. (Do not include an __init__.py module, and do not use python modules for reusable code). If you follow this simple architecture, your deployments will be almost entirely hands off.
+It is suggested that you develop your bots as scripts to keep your deployments simple.
+If you have a deep understanding of containerization, and have specific needs, you can set your bots up however you'd like, and then create your own container definitions for deployments to publish to your reqistry of choice.
+For the most streamlined experience, develop your bots as scripts, and avoid relying on local packages
+(e.g. do not include an `__init__.py` file inside your `bots/` directory, and do not use local modules inside `bots/` for reusable code).
+If you follow these suggestions, your Silverback deployments will be easy to use and require almost no thought.
 ```
 
 ## Creating an Application

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -14,6 +14,8 @@ If silverback finds a module named `bot.py` either in the `bots/` directory or a
 It will also be able to detect the scripts inside your `bots/` directory and let you run those by name (in case you have multiple bots in your project).
 It is suggested that you create the instance of your `SilverbackApp()` object by naming the variable `bot`, since `silverback` will autodetect that variable name when loading your script file.
 
+Another way you can structure your bot is to create a `bot` folder and define a runner inside of that folder as `__init__.py`. This method of setting up your project will not allow you to use `silverback build` currently, and you will have to define your own dockerfile. There is a below example of how to run an app defined in this manner.
+
 If you have a more complicated project that requires multiple bots, naming each bot their own individual name is okay to do, and we encourage you to locate them under the `bots/` folder relative to the root of your project.
 This will work fairly seamless with the rest of the examples shown in this guide.
 
@@ -41,8 +43,14 @@ We will automatically detect all scripts under the `bots/` folder automatically,
 silverback run folder.example:app --network your:network:of:choice
 ```
 
+With a `bot/__init__.py` setup, you can run with:
+
+```bash
+silverback run bot --network your:network:of:choice
+```
+
 ```{note}
-It is suggested that you develop your modules as scripts to keep your deployments simple. If you have a deep understanding of containerization, and distributed applications, you can set your bots up however you'd like, and then create your own container definitions for deployments. For a simple deployment ecosystem, develop your bots as scripts, and avoid developing your applications as packages. (Do not include an __init__.py module, and do not use python modules for reusable code). If you follow this simple architecture, your deployments will be nearly entirely hands off.
+It is suggested that you develop your modules as scripts to keep your deployments simple. If you have a deep understanding of containerization, and distributed applications, you can set your bots up however you'd like, and then create your own container definitions for deployments. For a simple deployment ecosystem, develop your bots as scripts, and avoid developing your applications as packages. (Do not include an __init__.py module, and do not use python modules for reusable code). If you follow this simple architecture, your deployments will be almost entirely hands off.
 ```
 
 ## Creating an Application

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -9,12 +9,24 @@ You can install Silverback via `pip install silverback`
 
 ## Project structure
 
-The `silverback` cli automatically searches for python scripts to run as bots in specific locations relative to the root of your project.
-If silverback finds a module named `bot.py` either in the `bots/` directory or at the root directory of the project, then it will use that by default.
-It will also be able to detect the scripts inside your `bots/` directory and let you run those by name (in case you have multiple bots in your project).
-It is suggested that you create the instance of your `SilverbackApp()` object by naming the variable `bot`, since `silverback` will autodetect that variable name when loading your script file.
+There are 3 suggested ways to structure your project:
 
-Another way you can structure your bot is to create a `bot` folder and define a runner inside of that folder as `__init__.py`. This method of setting up your project will not allow you to use `silverback build` currently, and you will have to define your own dockerfile. There is a below example of how to run an app defined in this manner.
+1. Create a `bot.py` file in the root directory of your project. This is the simplest way to define your bot project.
+
+2. Create a `bots/` folder in the root directory of your project. Then develop bots in this folder as separate scripts (Do not include a __init__.py file).
+
+3. Create a `bot/` folder with a `__init__.py` file that will include the instantiation of your `SilverbackApp()` object.
+
+The `silverback` cli automatically searches for python scripts to run as bots in specific locations relative to the root of your project.
+If `silverback` finds a module named `bot.py` either in the `bots/` directory or at the root directory of the project, then it will use that by default.
+It will also be able to detect the scripts inside your `bots/` directory and let you run those by name (in case you have multiple bots in your project).
+`silverback` can also deal with a `bot/` folder with an `__init__.py` file that is defined as the runner.
+
+```{note}
+It is suggested that you create the instance of your `SilverbackApp()` object by naming the variable `bot`, since `silverback` will autodetect that variable name when loading your script file.
+```
+
+Another way you can structure your bot is to create a `bot` folder and define a runner inside of that folder as `__init__.py`.
 
 If you have a more complicated project that requires multiple bots, naming each bot their own individual name is okay to do, and we encourage you to locate them under the `bots/` folder relative to the root of your project.
 This will work fairly seamless with the rest of the examples shown in this guide.
@@ -31,10 +43,10 @@ However, if your bot's module name is not `bot.py` but `example.py` (for example
 silverback run example --network your:network:of:choice
 ```
 
-If the variable that you call the `SilverbackApp()` object is something other than `bot`, you can specific that by adding `:{variable name}`:
+If the variable that you call the `SilverbackApp()` object is something other than `bot`, you can specific that by adding `:{variable-name}`:
 
 ```bash
-silverback run example:app --network your:network:of:choice
+silverback run example:{variable-name} --network your:network:of:choice
 ```
 
 We will automatically detect all scripts under the `bots/` folder automatically, but if your bot resides in a location other than `bots/` then you can use this to run it:

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -18,7 +18,6 @@ There are 3 suggested ways to structure your project:
 3. Create a `bot/` folder with a `__init__.py` file that will include the instantiation of your `SilverbackApp()` object.
 
 The `silverback` cli automatically searches for python scripts to run as bots in specific locations relative to the root of your project.
-If `silverback` finds a module named `bot.py` either in the `bots/` directory or at the root directory of the project, then it will use that by default.
 It will also be able to detect the scripts inside your `bots/` directory and let you run those by name (in case you have multiple bots in your project).
 `silverback` can also deal with a `bot/` folder with an `__init__.py` file that is defined as the runner.
 
@@ -31,13 +30,7 @@ Another way you can structure your bot is to create a `bot` folder and define a 
 If you have a more complicated project that requires multiple bots, naming each bot their own individual name is okay to do, and we encourage you to locate them under the `bots/` folder relative to the root of your project.
 This will work fairly seamless with the rest of the examples shown in this guide.
 
-To run a bot, as long as your project directory follows the suggestion above by using a `bot.py` script, you can run it easily with:
-
-```bash
-silverback run --network your:network:of:choice
-```
-
-However, if your bot's module name is not `bot.py` but `example.py` (for example), you can run it like this:
+If your bot's module name is `example.py` (for example), you can run it like this:
 
 ```bash
 silverback run example --network your:network:of:choice

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -10,7 +10,7 @@ You can install Silverback via `pip install silverback`
 ## Project structure
 
 The `silverback` cli automatically searches for python scripts to run as bots in specific locations relative to the root of your project.
-It if finds a module named `bot.py` either in the `bots/` directory or at the root directory of the project, then it will use that by default.
+If silverback finds a module named `bot.py` either in the `bots/` directory or at the root directory of the project, then it will use that by default.
 It will also be able to detect the scripts inside your `bots/` directory and let you run those by name (in case you have multiple bots in your project).
 It is suggested that you create the instance of your `SilverbackApp()` object by naming the variable `bot`, since `silverback` will autodetect that variable name when loading your script file.
 

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -19,7 +19,6 @@ There are 3 suggested ways to structure your project:
 
 The `silverback` cli automatically searches for python scripts to run as bots in specific locations relative to the root of your project.
 It will also be able to detect the scripts inside your `bots/` directory and let you run those by name (in case you have multiple bots in your project).
-`silverback` can also deal with a `bot/` folder with an `__init__.py` file that is defined as the runner.
 
 If `silverback` finds a module named `bot` in the root directory of the project, then it will use that by default.
 

--- a/docs/userguides/platform.md
+++ b/docs/userguides/platform.md
@@ -37,9 +37,13 @@ Building a container for your application can be an advanced topic, we have incl
 
 To build your container definition(s) for your bot(s), you can use the `silverback build` command. This command searches your `bots` directory for python modules, then auto-generates Dockerfiles.
 
-For example, if your directory is structured as suggested in [development](./development), the `silverback build` command would generate:
+For example, if your directory is structured as suggested in [development](./development), the `silverback build --generate` command would generate:
 
 As an example, if you have a bots directory that looks like:
+
+```bash
+silverback build --generate
+```
 
 ```
 bots/
@@ -60,7 +64,7 @@ This method will generate 3 Dockerfiles:
 You can then build your image using:
 
 ```bash
-docker build -t your-registry-url/project/botA:latest -f .silverback-images/Dockerfile.botA .
+silverback build
 ```
 
 You can then push your image to your registry using:

--- a/docs/userguides/platform.md
+++ b/docs/userguides/platform.md
@@ -35,7 +35,41 @@ Building a container for your application can be an advanced topic, we have incl
 
 ## Building your Bot
 
-TODO: Add build process and describe `silverback build --autogen` and `silverback build --upgrade`
+To build your container definition(s) for your bot(s), you can use the `silverback build` command. This command searches your `bots` directory for python modules, then auto-generates Dockerfiles.
+
+For example, if your directory is structured as suggested in [development](./development), the `silverback build` command would generate:
+
+As an example, if you have a bots directory that looks like:
+
+```
+bots/
+├── botA.py
+├── botB.py
+├── botC.py
+```
+
+This method will generate 3 Dockerfiles:
+
+```
+├── Dockerfile.botA
+├── Dockerfile.botB
+├── Dockerfile.botC
+```
+
+You can then build your image using:
+
+```bash
+docker build -t your-registry-url/project/botA:latest -f Dockerfile.botA .
+```
+
+You can then push your image to your registry using:
+
+```bash
+docker push your-registry-url/project/botA:latest
+```
+
+TODO: The ApeWorX team has github actions definitions for building, pushing and deploying. If you are unfamiliar with docker and container registries, you can use the ApeWorX github actions repository to assist in these steps.
+
 
 TODO: Add how to debug containers using `silverback run` w/ `taskiq-redis` broker
 

--- a/docs/userguides/platform.md
+++ b/docs/userguides/platform.md
@@ -77,7 +77,7 @@ docker push your-registry-url/project/botA:latest
 
 TODO: The ApeWorX team has github actions definitions for building, pushing and deploying.
 
-If you are unfamiliar with docker and container registries, you can use the [[github-action]].
+If you are unfamiliar with docker and container registries, you can use the \[\[github-action\]\].
 
 You do not need to build using this command if you use the github action, but it is there to help you if you are having problems figuring out how to build and run your bot images on the cluster successfully.
 

--- a/docs/userguides/platform.md
+++ b/docs/userguides/platform.md
@@ -77,7 +77,7 @@ docker push your-registry-url/project/botA:latest
 
 TODO: The ApeWorX team has github actions definitions for building, pushing and deploying.
 
-If you are unfamiliar with docker and container registries, you can use the [github-action](https://github.com/ApeWorX/github-action) github actions repository to assist in these steps.
+If you are unfamiliar with docker and container registries, you can use the [[github-action]].
 
 You do not need to build using this command if you use the github action, but it is there to help you if you are having problems figuring out how to build and run your bot images on the cluster successfully.
 

--- a/docs/userguides/platform.md
+++ b/docs/userguides/platform.md
@@ -69,8 +69,11 @@ You can then push your image to your registry using:
 docker push your-registry-url/project/botA:latest
 ```
 
-TODO: The ApeWorX team has github actions definitions for building, pushing and deploying. If you are unfamiliar with docker and container registries, you can use the ApeWorX github actions repository to assist in these steps.
+TODO: The ApeWorX team has github actions definitions for building, pushing and deploying.
 
+If you are unfamiliar with docker and container registries, you can use the [github-action](https://github.com/ApeWorX/github-action) github actions repository to assist in these steps.
+
+You do not need to build using this command if you use the github action.
 
 TODO: Add how to debug containers using `silverback run` w/ `taskiq-redis` broker
 

--- a/docs/userguides/platform.md
+++ b/docs/userguides/platform.md
@@ -51,6 +51,7 @@ bots/
 This method will generate 3 Dockerfiles:
 
 ```
+.silverback-images/
 ├── Dockerfile.botA
 ├── Dockerfile.botB
 ├── Dockerfile.botC
@@ -59,7 +60,7 @@ This method will generate 3 Dockerfiles:
 You can then build your image using:
 
 ```bash
-docker build -t your-registry-url/project/botA:latest -f Dockerfile.botA .
+docker build -t your-registry-url/project/botA:latest -f .silverback-images/Dockerfile.botA .
 ```
 
 You can then push your image to your registry using:

--- a/docs/userguides/platform.md
+++ b/docs/userguides/platform.md
@@ -63,7 +63,7 @@ This method will generate 3 Dockerfiles:
 ├── Dockerfile.botC
 ```
 
-You can then build your image using:
+You can retry you builds using the following (assuming you don't modify the structure of your project):
 
 ```bash
 silverback build

--- a/docs/userguides/platform.md
+++ b/docs/userguides/platform.md
@@ -37,19 +37,21 @@ Building a container for your application can be an advanced topic, we have incl
 
 To build your container definition(s) for your bot(s), you can use the `silverback build` command. This command searches your `bots` directory for python modules, then auto-generates Dockerfiles.
 
-For example, if your directory is structured as suggested in [development](./development), the `silverback build --generate` command would generate:
-
-As an example, if you have a bots directory that looks like:
-
-```bash
-silverback build --generate
-```
+For example, if your directory is structured as suggested in [development](./development), and your `bots/` directory looks like this:
 
 ```
 bots/
 ├── botA.py
 ├── botB.py
 ├── botC.py
+```
+
+Then you can use `silverback build --generate` to generate 3 separate Dockerfiles for those bots, and start trying to build them.
+
+Those Dockerfiles will appear under `.silverback-images/` as follows:
+
+```bash
+silverback build --generate
 ```
 
 This method will generate 3 Dockerfiles:

--- a/docs/userguides/platform.md
+++ b/docs/userguides/platform.md
@@ -79,7 +79,7 @@ TODO: The ApeWorX team has github actions definitions for building, pushing and 
 
 If you are unfamiliar with docker and container registries, you can use the [github-action](https://github.com/ApeWorX/github-action) github actions repository to assist in these steps.
 
-You do not need to build using this command if you use the github action.
+You do not need to build using this command if you use the github action, but it is there to help you if you are having problems figuring out how to build and run your bot images on the cluster successfully.
 
 TODO: Add how to debug containers using `silverback run` w/ `taskiq-redis` broker
 

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -155,7 +155,7 @@ def generate_dockerfiles(path):
         if "__init__" in file.name:
             if not click.confirm(
                 "There is an __init__.py file in the bots directory,\n"
-                "making the bots/ directory a python package.\n"
+                f"making the {path}/ directory a python package.\n"
                 "Are you sure you want to generate a Dockerfile for all "
                 "files in this directory?"
             ):
@@ -165,7 +165,7 @@ def generate_dockerfiles(path):
     for bot in bots:
         docker_filename = f"Dockerfile.{bot.name.replace('.py', '')}"
         dockerfile_content = DOCKERFILE_CONTENT
-        dockerfile_content += f"COPY bots/{bot.name} bots/"
+        dockerfile_content += f"COPY {path.name}/{bot.name} bots/"
         with open(dockerfile_path := Path.cwd() / docker_filename, "w") as df:
             df.write(dockerfile_content.strip() + "\n")
         click.echo(f"Generated {dockerfile_path}")

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -19,7 +19,7 @@ from silverback._click_ext import (
     cls_import_callback,
     cluster_client,
     display_login_message,
-    path_callback,
+    bot_path_callback,
     platform_client,
 )
 from silverback.cluster.client import ClusterClient, PlatformClient
@@ -101,7 +101,7 @@ def _network_callback(ctx, param, val):
 )
 @click.option("-x", "--max-exceptions", type=int, default=3)
 @click.argument("path", required=False, type=str, default="bot")
-@click.argument("bot", required=False, callback=path_callback)
+@click.argument("bot", required=False, callback=bot_path_callback)
 def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path, bot):
     """Run Silverback application"""
 
@@ -165,7 +165,7 @@ def generate_dockerfiles(path):
 @click.option("-x", "--max-exceptions", type=int, default=3)
 @click.option("-s", "--shutdown_timeout", type=int, default=90)
 @click.argument("path", required=False, type=str, default="bot")
-@click.argument("bot", required=False, callback=path_callback)
+@click.argument("bot", required=False, callback=bot_path_callback)
 def worker(cli_ctx, account, workers, max_exceptions, shutdown_timeout, path, bot):
     """Run Silverback task workers (advanced)"""
     asyncio.run(run_worker(bot.broker, worker_count=workers, shutdown_timeout=shutdown_timeout))

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -100,7 +100,7 @@ def _network_callback(ctx, param, val):
     callback=cls_import_callback,
 )
 @click.option("-x", "--max-exceptions", type=int, default=3)
-@click.argument("path", required=False, type=str, default=None)
+@click.argument("path", required=False, type=str, default="bot")
 def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
     """Run Silverback application"""
 

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -106,6 +106,17 @@ def _network_callback(ctx, param, val):
 def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
     """Run Silverback application"""
 
+    def path_callback(path):
+        if not path:
+            path = "bot:bot"
+        elif ":" not in path:
+            path += ":bot"
+
+        try:
+            return import_from_string(path)
+        except ImportFromStringError:
+            return import_from_string(f"bots.{path}")
+
     if not runner_class:
         # NOTE: Automatically select runner class
         if cli_ctx.provider.ws_uri:
@@ -117,15 +128,7 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
                 option_name="network", message="Network choice cannot support running app"
             )
 
-    if not path:
-        path = "bot:bot"
-    elif ":" not in path:
-        path += ":bot"
-
-    try:
-        bot = import_from_string(path)
-    except ImportFromStringError:
-        bot = import_from_string(f"bots.{path}")
+    bot = path_callback(path)
 
     runner = runner_class(
         bot,

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -166,12 +166,11 @@ def generate_dockerfiles(path):
 @click.option("-w", "--workers", type=int, default=2)
 @click.option("-x", "--max-exceptions", type=int, default=3)
 @click.option("-s", "--shutdown_timeout", type=int, default=90)
-@click.argument("path")
-def worker(cli_ctx, account, workers, max_exceptions, shutdown_timeout, path):
+@click.argument("path", required=False, type=str, default="bot")
+@click.argument("bot", required=False, callback=path_callback)
+def worker(cli_ctx, account, workers, max_exceptions, shutdown_timeout, path, bot):
     """Run Silverback task workers (advanced)"""
-
-    app = import_from_string(path)
-    asyncio.run(run_worker(app.broker, worker_count=workers, shutdown_timeout=shutdown_timeout))
+    asyncio.run(run_worker(bot.broker, worker_count=workers, shutdown_timeout=shutdown_timeout))
 
 
 @cli.command(section="Cloud Commands (https://silverback.apeworx.io)")

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -118,13 +118,28 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
     if path is None:
         path = Path.cwd() / "bots" / "bot.py"
         if not path.parent.exists():
-            raise FileNotFoundError(
-                f"The bots directory '{path}' does not exist."
-                f"You should have a `bots/` folder in the root of your project."
+            click.secho(
+                "Warning: the bots/ directory does not exist. "
+                "It is recommended have a `bots/` folder in the root "
+                "of your project.",
+                fg='yellow',
+                bold=True,
             )
-        elif not path.exists():
+            path = path.parent.parent / "bot.py"
+        if not path.exists():
+            click.secho(
+                f"Error: the 'bot.py' file could not be found. "
+                "you must apply the `-p` path option in your "
+                "function call to inform this method of where "
+                "your bot exists.",
+                fg='red',
+                bold=True,
+            )
             raise FileNotFoundError("The bot.py file does not exist in the bots directory.")
-        path = f"{path.parent.name}.{path.name.replace('.py', '')}:bot"
+        path = f"{path.parent.name}.{path.name.replace('.py', '')}"
+
+    if ":" not in path:
+        path += ":bot"
 
     app = import_from_string(path)
     runner = runner_class(

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -117,7 +117,7 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
 
     if not (bots_folder := Path.cwd() / "bots").exists():
         raise FileNotFoundError(
-            f"The bots directory '{path}' does not exist."
+            f"The bots directory '{path}' does not exist. "
             f"You should have a `bots/` folder in the root of your project."
         )
 
@@ -142,8 +142,13 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
 
 
 @cli.command(cls=ConnectedProviderCommand, section="Local Commands")
-def generate_dockerfiles():
-    path = Path.cwd() / "bots"
+@click.argument("path", required=False, type=str, default="bots")
+def generate_dockerfiles(path):
+    if not (path := Path.cwd() / path).exists():
+        raise FileNotFoundError(
+            f"The bots directory '{path}' does not exist. "
+            "You should have a `{path}/` folder in the root of your project."
+        )
     files = {file for file in path.iterdir() if file.is_file()}
     bots = []
     for file in files:

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -102,9 +102,8 @@ def _network_callback(ctx, param, val):
     callback=cls_import_callback,
 )
 @click.option("-x", "--max-exceptions", type=int, default=3)
-@click.argument("path", required=False, type=str, default="bot")
 @click.argument("bot", required=False, callback=bot_path_callback)
-def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path, bot):
+def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, bot):
     """Run Silverback application"""
 
     if not runner_class:
@@ -190,9 +189,8 @@ def build(generate, path):
 @click.option("-w", "--workers", type=int, default=2)
 @click.option("-x", "--max-exceptions", type=int, default=3)
 @click.option("-s", "--shutdown_timeout", type=int, default=90)
-@click.argument("path", required=False, type=str, default="bot")
 @click.argument("bot", required=False, callback=bot_path_callback)
-def worker(cli_ctx, account, workers, max_exceptions, shutdown_timeout, path, bot):
+def worker(cli_ctx, account, workers, max_exceptions, shutdown_timeout, bot):
     """Run Silverback task workers (advanced)"""
     asyncio.run(run_worker(bot.broker, worker_count=workers, shutdown_timeout=shutdown_timeout))
 

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -100,7 +100,7 @@ def _network_callback(ctx, param, val):
     callback=cls_import_callback,
 )
 @click.option("-x", "--max-exceptions", type=int, default=3)
-@click.argument("path", type=str, default=None)
+@click.argument("path", required=False, type=str, default=None)
 def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
     """Run Silverback application"""
 

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -106,7 +106,7 @@ def _network_callback(ctx, param, val):
 def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
     """Run Silverback application"""
 
-    def path_callback(path):
+    def path_callback(path, calls=0):
         if not path:
             path = "bot:bot"
         elif ":" not in path:
@@ -114,8 +114,11 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
 
         try:
             return import_from_string(path)
-        except ImportFromStringError:
-            return import_from_string(f"bots.{path}")
+        except ImportFromStringError as e:
+            if calls > 0:
+                raise ImportFromStringError(e)
+            calls += 1
+            return path_callback(f"bots.{path}", calls)
 
     if not runner_class:
         # NOTE: Automatically select runner class

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -127,7 +127,7 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path, bo
     asyncio.run(runner.run())
 
 
-@cli.command(cls=ConnectedProviderCommand, section="Local Commands")
+@cli.command(section="Local Commands")
 @click.option("--generate", is_flag=True, default=False)
 @click.argument("path", required=False, type=str, default="bots")
 def build(generate, path):

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -126,7 +126,7 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path, bo
 
 @cli.command(cls=ConnectedProviderCommand, section="Local Commands")
 @click.argument("path", required=False, type=str, default="bots")
-def generate_dockerfiles(path):
+def build(path):
     if not (path := Path.cwd() / path).exists():
         raise FileNotFoundError(
             f"The bots directory '{path}' does not exist. "

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -33,7 +33,7 @@ DOCKERFILE_CONTENT = """
 FROM ghcr.io/apeworx/silverback:stable
 USER root
 WORKDIR /app
-RUN mkdir -p ./bots && chown harambe:harambe /app/bots
+RUN chown harambe:harambe /app
 USER harambe
 COPY ape-config.yaml .
 COPY requirements.txt .
@@ -144,12 +144,13 @@ def build(generate, path):
                 break
             bots.append(file)
         for bot in bots:
+            dockerfile_content = DOCKERFILE_CONTENT
             if "__init__" in bot.name:
                 docker_filename = f"Dockerfile.{bot.parent.name}"
+                dockerfile_content += f"COPY {path.name}/ /app/bot"
             else:
                 docker_filename = f"Dockerfile.{bot.name.replace('.py', '')}"
-            dockerfile_content = DOCKERFILE_CONTENT
-            dockerfile_content += f"COPY {path.name}/{bot.name} bots/bot.py"
+                dockerfile_content += f"COPY {path.name}/{bot.name} /app/bot.py"
             dockerfile_path = Path.cwd() / ".silverback-images" / docker_filename
             dockerfile_path.parent.mkdir(exist_ok=True)
             dockerfile_path.write_text(dockerfile_content.strip() + "\n")

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -124,9 +124,7 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
                 f"You should have a `bots/` folder in the root of your project."
             )
         elif not path.exists():
-            raise FileNotFoundError(
-                f"The bot.py file does not exist in the bots directory."
-            )
+            raise FileNotFoundError(f"The bot.py file does not exist in the bots directory.")
         path = f"{path.parent.name}.{path.name.replace('.py', '')}:bot"
 
     app = import_from_string(path)
@@ -144,7 +142,7 @@ def generate_dockerfiles():
     files = {file for file in path.iterdir() if file.is_file()}
     bots = []
     for file in files:
-        if '__init__' in file.name:
+        if "__init__" in file.name:
             if not click.confirm(
                 "There is an __init__.py file in the bots directory,\n"
                 "making the bots/ directory a python package.\n"

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -1,12 +1,11 @@
 import asyncio
 import os
+import shlex
+import subprocess
 from pathlib import Path
 
 import click
-import shlex
-import subprocess
 import yaml  # type: ignore[import-untyped]
-
 from ape.cli import (
     AccountAliasPromptChoice,
     ConnectedProviderCommand,
@@ -146,7 +145,7 @@ def build(generate, path):
                 break
             bots.append(file)
         for bot in bots:
-            if '__init__' in bot.name:
+            if "__init__" in bot.name:
                 docker_filename = f"Dockerfile.{bot.parent.name}"
             else:
                 docker_filename = f"Dockerfile.{bot.name.replace('.py', '')}"
@@ -167,14 +166,12 @@ def build(generate, path):
     for file in dockerfiles:
         try:
             command = shlex.split(
-                f"docker build -f ./{file.parent.name}/{file.name} -t {file.name.split('.')[1]}:latest ."
+                "docker build -f "
+                f"./{file.parent.name}/{file.name} "
+                f"-t {file.name.split('.')[1]}:latest ."
             )
             result = subprocess.run(
-                command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                check=True
+                command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
             )
             click.echo(result.stdout)
         except subprocess.CalledProcessError as e:

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -1,8 +1,8 @@
 import asyncio
 import os
+from pathlib import Path
 
 import click
-from pathlib import Path
 import yaml  # type: ignore[import-untyped]
 from ape.cli import (
     AccountAliasPromptChoice,
@@ -27,8 +27,7 @@ from silverback.cluster.types import ClusterTier
 from silverback.runner import PollingRunner, WebsocketRunner
 from silverback.worker import run_worker
 
-
-DOCKERFILE_CONTENT = f"""
+DOCKERFILE_CONTENT = """
 FROM ghcr.io/apeworx/silverback:latest-slim
 USER root
 WORKDIR /app
@@ -124,7 +123,7 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
                 f"You should have a `bots/` folder in the root of your project."
             )
         elif not path.exists():
-            raise FileNotFoundError(f"The bot.py file does not exist in the bots directory.")
+            raise FileNotFoundError("The bot.py file does not exist in the bots directory.")
         path = f"{path.parent.name}.{path.name.replace('.py', '')}:bot"
 
     app = import_from_string(path)

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -148,7 +148,7 @@ def generate_dockerfiles(path):
     for bot in bots:
         docker_filename = f"Dockerfile.{bot.name.replace('.py', '')}"
         dockerfile_content = DOCKERFILE_CONTENT
-        dockerfile_content += f"COPY {path.name}/{bot.name} bots/"
+        dockerfile_content += f"COPY {path.name}/{bot.name} bots/bot.py"
         with open(dockerfile_path := Path.cwd() / docker_filename, "w") as df:
             df.write(dockerfile_content.strip() + "\n")
         click.echo(f"Generated {dockerfile_path}")

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -30,7 +30,7 @@ from silverback.worker import run_worker
 from .exceptions import ImportFromStringError
 
 DOCKERFILE_CONTENT = """
-FROM ghcr.io/apeworx/silverback:latest
+FROM ghcr.io/apeworx/silverback:stable
 USER root
 WORKDIR /app
 RUN mkdir -p ./bots && chown harambe:harambe /app/bots

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -127,6 +127,7 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path, bo
 @cli.command(cls=ConnectedProviderCommand, section="Local Commands")
 @click.argument("path", required=False, type=str, default="bots")
 def build(path):
+    """Auto-generate Dockerfiles"""
     if not (path := Path.cwd() / path).exists():
         raise FileNotFoundError(
             f"The bots directory '{path}' does not exist. "

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -150,8 +150,9 @@ def build(path):
         docker_filename = f"Dockerfile.{bot.name.replace('.py', '')}"
         dockerfile_content = DOCKERFILE_CONTENT
         dockerfile_content += f"COPY {path.name}/{bot.name} bots/bot.py"
-        with open(dockerfile_path := Path.cwd() / docker_filename, "w") as df:
-            df.write(dockerfile_content.strip() + "\n")
+        dockerfile_path = Path.cwd() / ".silverback-images" / docker_filename
+        dockerfile_path.parent.mkdir(exist_ok=True)
+        dockerfile_path.write_text(dockerfile_content.strip() + "\n")
         click.echo(f"Generated {dockerfile_path}")
 
 

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -122,9 +122,7 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
         )
 
     elif not (bots_folder / f"{path}.py").exists():
-        raise FileNotFoundError(
-            f"The file '{path}.py' does not exist in the `bots/` directory."
-        )
+        raise FileNotFoundError(f"The file '{path}.py' does not exist in the `bots/` directory.")
 
     else:
         path = f"bots.{path}:bot"

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -115,28 +115,19 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
                 option_name="network", message="Network choice cannot support running app"
             )
 
-    if path is None:
-        path = Path.cwd() / "bots" / "bot.py"
-        if not path.parent.exists():
-            click.secho(
-                "Warning: the bots/ directory does not exist. "
-                "It is recommended have a `bots/` folder in the root "
-                "of your project.",
-                fg='yellow',
-                bold=True,
-            )
-            path = path.parent.parent / "bot.py"
-        if not path.exists():
-            click.secho(
-                f"Error: the 'bot.py' file could not be found. "
-                "you must apply the `-p` path option in your "
-                "function call to inform this method of where "
-                "your bot exists.",
-                fg='red',
-                bold=True,
-            )
-            raise FileNotFoundError("The bot.py file does not exist in the bots directory.")
-        path = f"{path.parent.name}.{path.name.replace('.py', '')}"
+    if not (bots_folder := Path.cwd() / "bots").exists():
+        raise FileNotFoundError(
+            f"The bots directory '{path}' does not exist."
+            f"You should have a `bots/` folder in the root of your project."
+        )
+
+    elif not (bots_folder / f"{path}.py").exists():
+        raise FileNotFoundError(
+            f"The file '{path}.py' does not exist in the `bots/` directory."
+        )
+
+    else:
+        path = f"bots.{path}:bot"
 
     if ":" not in path:
         path += ":bot"

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -19,15 +19,13 @@ from silverback._click_ext import (
     cls_import_callback,
     cluster_client,
     display_login_message,
-    platform_client,
     path_callback,
+    platform_client,
 )
-from silverback._importer import import_from_string
 from silverback.cluster.client import ClusterClient, PlatformClient
 from silverback.cluster.types import ClusterTier
 from silverback.runner import PollingRunner, WebsocketRunner
 from silverback.worker import run_worker
-
 
 DOCKERFILE_CONTENT = """
 FROM ghcr.io/apeworx/silverback:stable

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -30,7 +30,7 @@ from silverback.worker import run_worker
 from .exceptions import ImportFromStringError
 
 DOCKERFILE_CONTENT = """
-FROM ghcr.io/apeworx/silverback:latest-slim
+FROM ghcr.io/apeworx/silverback:latest
 USER root
 WORKDIR /app
 RUN mkdir -p ./bots && chown harambe:harambe /app/bots

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -100,7 +100,7 @@ def _network_callback(ctx, param, val):
     callback=cls_import_callback,
 )
 @click.option("-x", "--max-exceptions", type=int, default=3)
-@click.option("-p", "--path", type=str, default=None)
+@click.argument("path", type=str, default=None)
 def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path):
     """Run Silverback application"""
 

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -16,10 +16,10 @@ from fief_client.integrations.cli import FiefAuth
 from silverback._click_ext import (
     SectionedHelpGroup,
     auth_required,
+    bot_path_callback,
     cls_import_callback,
     cluster_client,
     display_login_message,
-    bot_path_callback,
     platform_client,
 )
 from silverback.cluster.client import ClusterClient, PlatformClient

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -131,7 +131,7 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, path, bo
 @click.option("--generate", is_flag=True, default=False)
 @click.argument("path", required=False, type=str, default="bots")
 def build(generate, path):
-    """Auto-generate Dockerfiles"""
+    """Generate Dockerfiles and build bot images"""
     if generate:
         if not (path := Path.cwd() / path).exists():
             raise FileNotFoundError(

--- a/silverback/_click_ext.py
+++ b/silverback/_click_ext.py
@@ -258,7 +258,7 @@ def cluster_client(f):
     return update_wrapper(get_cluster_client, f)
 
 
-def path_callback(ctx: click.Context, param: click.Parameter, value):
+def bot_path_callback(ctx: click.Context, param: click.Parameter, value):
     path = ctx.params.get("path")
     if not path:
         path = "bot:bot"

--- a/silverback/_click_ext.py
+++ b/silverback/_click_ext.py
@@ -14,6 +14,7 @@ from silverback.cluster.settings import (
     PlatformProfile,
     ProfileSettings,
 )
+
 from .exceptions import ImportFromStringError
 
 # NOTE: only load once
@@ -258,7 +259,7 @@ def cluster_client(f):
 
 
 def path_callback(ctx: click.Context, param: click.Parameter, value):
-    path = ctx.params.get('path')
+    path = ctx.params.get("path")
     if not path:
         path = "bot:bot"
     elif ":" not in path:
@@ -266,6 +267,5 @@ def path_callback(ctx: click.Context, param: click.Parameter, value):
 
     try:
         return import_from_string(path)
-    except ImportFromStringError as e:
+    except ImportFromStringError:
         return import_from_string(f"bots.{path}")
-

--- a/silverback/_click_ext.py
+++ b/silverback/_click_ext.py
@@ -258,8 +258,7 @@ def cluster_client(f):
     return update_wrapper(get_cluster_client, f)
 
 
-def bot_path_callback(ctx: click.Context, param: click.Parameter, value: str | None):
-    path = ctx.params.get("path")
+def bot_path_callback(ctx: click.Context, param: click.Parameter, path: str | None):
     if not path:
         path = "bot:bot"
     elif ":" not in path:

--- a/silverback/_click_ext.py
+++ b/silverback/_click_ext.py
@@ -258,7 +258,7 @@ def cluster_client(f):
     return update_wrapper(get_cluster_client, f)
 
 
-def bot_path_callback(ctx: click.Context, param: click.Parameter, value):
+def bot_path_callback(ctx: click.Context, param: click.Parameter, value: str | None):
     path = ctx.params.get("path")
     if not path:
         path = "bot:bot"

--- a/silverback/_click_ext.py
+++ b/silverback/_click_ext.py
@@ -14,6 +14,7 @@ from silverback.cluster.settings import (
     PlatformProfile,
     ProfileSettings,
 )
+from .exceptions import ImportFromStringError
 
 # NOTE: only load once
 settings = ProfileSettings.from_config_file()
@@ -254,3 +255,17 @@ def cluster_client(f):
         return ctx.invoke(f, *args, **kwargs)
 
     return update_wrapper(get_cluster_client, f)
+
+
+def path_callback(ctx: click.Context, param: click.Parameter, value):
+    path = ctx.params.get('path')
+    if not path:
+        path = "bot:bot"
+    elif ":" not in path:
+        path += ":bot"
+
+    try:
+        return import_from_string(path)
+    except ImportFromStringError as e:
+        return import_from_string(f"bots.{path}")
+


### PR DESCRIPTION
### What I did

In an attempt to make the dev ux simpler, I allow for the path to be an option. If the path does not exist, we set the bath to `pathlib.Path.cwd()/bots/bot.py`

We check and raise if the file and/or the directory does not exist.

We are also adding a `Dockerfile` generator to the `_cli.py` file that will search the `bots/` directory for filenames. Each filename will be generated as a `Dockerfile.<filename>`. The Dockerfile will copy the filename into the `bots/` directory as `bot.py`.

fixes: #122 
fixes: #123 
fixes: SBK-564
fixes: SBK-563

### How I did it

Made minor changes to the `run` command and adding a method to generate the dockerfiles.

### How to verify it

Without a `bots/` directory in the root of the project run:
```
silverback run --network ethereum:mainnet
```
This will raise and show a:
```
FileNotFoundError: The bots directory '/path/to/silverback/bots' does not exist. You should have a `bots/` folder in the root of your project.
```
Then:
```
mkdir bots
silverback run --network ethereum:mainnet
```
This will raise and show:
```
FileNotFoundError: The bot.py file does not exist in the bots directory.
```
You can then run:
```
touch bots/bot.py
silverback run --network ethereum:mainnet
```
And you will get an error that does not relate to files missing.
You can also run:
```
touch bots/some_file.py
silverback run bots.some_file:bot
```
And you will get an error that does not pertain to the files/directory missing. 

MORE TO BE ADDED

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
