### PR TITLE
fix: warn the user (instead of DEBUG) log when runtime exit

### DIFF
--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -234,7 +234,7 @@ class BaseRunner(ABC):
         )
         if runtime_errors := "\n".join(str(task.exception()) for task in tasks_with_errors):
             # NOTE: In case we are somehow not displaying the error correctly with task status
-            logger.debug(f"Runtime error(s) detected, shutting down:\n{runtime_errors}")
+            logger.warning(f"Runtime error(s) detected, shutting down:\n{runtime_errors}")
 
         # Cancel any still running
         (task.cancel() for task in tasks_running)


### PR DESCRIPTION
### What I did

fixes: #124 

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
