### PR TITLE
refactor: display task start with INFO instead of DEBUG

### DIFF
--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -85,7 +85,7 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
             message.labels["transaction_hash"] = log.transaction_hash
             message.labels["log_index"] = str(log.log_index)
 
-        logger.debug(f"{self._create_label(message)} - Started")
+        logger.info(f"{self._create_label(message)} - Started")
         return message
 
     def post_execute(self, message: TaskiqMessage, result: TaskiqResult):


### PR DESCRIPTION
### What I did

If you have a *long* running task, you can't actually see when it starts by default, making you think nothing is running

This seems like a devex improvement

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
