### PR TITLE
fix(cluster): vargroup "latest" doesn't work

### DIFF
--- a/silverback/cluster/client.py
+++ b/silverback/cluster/client.py
@@ -112,7 +112,7 @@ class VariableGroup(VariableGroupInfo):
     def get_revision(self, revision: int | Literal["latest"] = "latest") -> VariableGroupInfo:
         # TODO: Add `/latest` revision route
         if revision == "latest":
-            revision = ""  # type: ignore[assignment]
+            revision = -1  # NOTE: This works with how cluster does lookup
 
         response = self.cluster.get(f"/variables/{self.id}/{revision}")
         handle_error_with_response(response)


### PR DESCRIPTION
### What I did

```sh
$ silverback cluster bots new -g <some vargroup> ...
...                                                                                                                              
  File "site-packages/silverback/_cli.py", line 859, in new_bot                                                      
    environment = [cluster.variable_groups[vg_name].get_revision("latest") for vg_name in vargroups]                                                                              
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                        
  File "site-packages/silverback/cluster/client.py", line 118, in get_revision                                       
    handle_error_with_response(response)                                                                                                                                          
  File "site-packages/silverback/cluster/client.py", line 54, in handle_error_with_response                          
    raise RuntimeError(message)                                                                                                                                                   
RuntimeError: Not Found
```
### How I did it

### How to verify it

I tested locally w/ `staging` cluster

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
