### PR TITLE
fix: auto run update

### DIFF
--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -44,7 +44,7 @@ USER harambe
 COPY ape-config.yaml .
 COPY requirements.txt .
 RUN pip install --upgrade pip && pip install -r requirements.txt
-RUN ape plugins install .
+RUN ape plugins install -U .
 """
 
 


### PR DESCRIPTION
### What I did

If there are already plugins installed, the install command fails unless you call to update

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
