### PR TITLE
fix: cluster and workspace form data

### DIFF
--- a/silverback/cluster/client.py
+++ b/silverback/cluster/client.py
@@ -358,7 +358,7 @@ class Workspace(WorkspaceInfo):
         response = self.client.post(
             "/clusters/",
             params=dict(workspace=str(self.id)),
-            json=dict(name=cluster_name, slug=cluster_slug),
+            data=dict(name=cluster_name, slug=cluster_slug),
         )
 
         handle_error_with_response(response)
@@ -426,7 +426,7 @@ class PlatformClient(httpx.Client):
     ) -> Workspace:
         response = self.post(
             "/workspaces",
-            json=dict(slug=workspace_slug, name=workspace_name),
+            data=dict(slug=workspace_slug, name=workspace_name),
         )
         handle_error_with_response(response)
         new_workspace = Workspace.model_validate_json(response.text)


### PR DESCRIPTION
### What I did
Fixes the cluster & Workspace create/update must use Form encoded data, not JSON body (use data= instead of json=)
<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #137 

### How I did it

### How to verify it
Tested creating clusters with cli and it works.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
