### PR TITLE
fix: silverback build missing files during generate

### DIFF
--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Union
 
 import click
+from ape.utils.os import clean_path
 
 DOCKERFILE_CONTENT = """
 FROM ghcr.io/apeworx/silverback:stable
@@ -65,6 +66,7 @@ class DockerfileGenerator:
         """
         Will generate a file based on path type
         """
+        raise NotImplementedError(f"Path type {type(path)} not supported")
 
     @generate_dockerfiles.register
     def _(self, path: FilePath):
@@ -93,7 +95,7 @@ class DockerfileGenerator:
         dockerfile_path = Path.cwd() / ".silverback-images" / self.dockerfile_name
         dockerfile_path.parent.mkdir(exist_ok=True)
         dockerfile_path.write_text(dockerfile_c.strip() + "\n")
-        click.echo(f"Generated {dockerfile_path}")
+        click.echo(f"Generated {clean_path(dockerfile_path)}")
 
     def _check_for_requirements(self, dockerfile_content):
         if (Path.cwd() / "requirements.txt").exists():

--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -15,6 +15,7 @@ USER harambe
 """
 
 
+# Note: Python3.12 supports subclassing pathlib.Path
 class BasePath(Path):
     _flavour = type(Path())._flavour
     _parse_args = type(Path())._parse_args

--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -1,0 +1,119 @@
+from typing import Union
+
+import click
+
+from functools import singledispatchmethod
+from pathlib import Path
+
+
+DOCKERFILE_CONTENT = """
+FROM ghcr.io/apeworx/silverback:stable
+USER root
+WORKDIR /app
+RUN chown harambe:harambe /app
+USER harambe
+"""
+
+
+class BasePath(Path):
+    _flavour = type(Path())._flavour
+    _parse_args = type(Path())._parse_args
+
+
+class FilePath(BasePath):
+    """A subclass of Path representing a file."""
+
+
+class DirPath(BasePath):
+    """A subclass of Path representing a path"""
+
+
+def generate_path(path: Path):
+    if path.is_file():
+        return FilePath(str(path))
+    elif path.is_dir():
+        return DirPath(str(path))
+    else:
+        raise ValueError(
+            f"{path} is neither a file nor a directory"
+        )
+
+
+PathType = Union[
+    "FilePath",
+    "DirPath"
+]
+
+def generate_dockerfiles(path: Path):
+    path = generate_path(path)
+    dg = DockerfileGenerator()
+    breakpoint()
+    dg.generate_dockerfiles(path)
+
+class DockerfileGenerator:
+
+    @property
+    def dockerfile_name(self):
+        return self._dockerfile_name
+
+    @dockerfile_name.setter
+    def dockerfile_name(self, name):
+        self._dockerfile_name = name
+
+    @singledispatchmethod
+    def generate_dockerfiles(self, path: PathType):
+        """
+        Will generate a file based on path type
+        """
+
+    @generate_dockerfiles.register
+    def _(self, path: FilePath):
+        dockerfile_content = self._check_for_requirements(DOCKERFILE_CONTENT)
+        self.dockerfile_name = f"Dockerfile.{path.parent.name}-bot"
+        dockerfile_content += f"COPY {path.name}/ /app/bot.py\n"
+        self._build_helper(dockerfile_content)
+
+    @generate_dockerfiles.register
+    def _(self, path: DirPath):
+        bots = self._get_all_bot_files(path)
+        for bot in bots:
+            dockerfile_content = self._check_for_requirements(DOCKERFILE_CONTENT)
+            if bot.name == "__init__.py" or bot.name == "bot.py":
+                self.dockerfile_name = f"Dockerfile.{bot.parent.parent.name}-bot"
+                dockerfile_content += f"COPY {path.name}/ /app/bot\n"
+            else:
+                self.dockerfile_name = f"Dockerfile.{bot.name.replace('.py', '')}"
+                dockerfile_content += f"COPY {path.name}/{bot.name} /app/bot.py\n"
+            self._build_helper(dockerfile_content)
+
+    def _build_helper(self, dockerfile_c: str):
+        """
+        Used in multiple places in build.
+        """
+        dockerfile_path = Path.cwd() / ".silverback-images" / self.dockerfile_name
+        dockerfile_path.parent.mkdir(exist_ok=True)
+        dockerfile_path.write_text(dockerfile_c.strip() + "\n")
+        click.echo(f"Generated {dockerfile_path}")
+
+    def _check_for_requirements(self, dockerfile_content):
+        if (Path.cwd() / "requirements.txt").exists():
+            dockerfile_content += "COPY requirements.txt .\n"
+            dockerfile_content += (
+                "RUN pip install --upgrade pip && pip install -r requirements.txt\n"
+            )
+
+        if (Path.cwd() / "ape-config.yaml").exists():
+            dockerfile_content += "COPY ape-config.yaml .\n"
+            dockerfile_content += "RUN ape plugins install -U .\n"
+
+        return dockerfile_content
+
+    def _get_all_bot_files(self, path: DirPath):
+        files = sorted({file for file in path.iterdir() if file.is_file()}, reverse=True)
+        bots = []
+        for file in files:
+            if file.name == "__init__.py" or file.name == "bot.py":
+                bots = [file]
+                break
+            bots.append(file)
+        return bots

--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -1,12 +1,10 @@
+import shlex
+import subprocess
+from functools import singledispatchmethod
+from pathlib import Path
 from typing import Union
 
 import click
-import shlex
-import subprocess
-
-from functools import singledispatchmethod
-from pathlib import Path
-
 
 DOCKERFILE_CONTENT = """
 FROM ghcr.io/apeworx/silverback:stable
@@ -37,15 +35,11 @@ def generate_path(path: Path):
     elif path.is_dir():
         return DirPath(str(path))
     else:
-        raise ValueError(
-            f"{path} is neither a file nor a directory"
-        )
+        raise ValueError(f"{path} is neither a file nor a directory")
 
 
-PathType = Union[
-    "FilePath",
-    "DirPath"
-]
+PathType = Union["FilePath", "DirPath"]
+
 
 def generate_dockerfiles(path: Path):
     path = generate_path(path)

--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -29,7 +29,7 @@ class DirPath(BasePath):
     """A subclass of Path representing a path"""
 
 
-def generate_path(path: Path):
+def get_path(path: Path):
     if path.is_file():
         return FilePath(str(path))
     elif path.is_dir():
@@ -42,13 +42,13 @@ PathType = Union["FilePath", "DirPath"]
 
 
 def generate_dockerfiles(path: Path):
-    path = generate_path(path)
+    path = get_path(path)
     dg = DockerfileGenerator()
     dg.generate_dockerfiles(path)
 
 
-def generate_docker_images(path: Path):
-    DockerfileGenerator.generate_images(path)
+def build_docker_images(path: Path):
+    DockerfileGenerator.build_images(path)
 
 
 class DockerfileGenerator:
@@ -121,7 +121,7 @@ class DockerfileGenerator:
         return bots
 
     @staticmethod
-    def generate_images(path: Path):
+    def build_images(path: Path):
         dockerfiles = {file for file in path.iterdir() if file.is_file()}
         for file in dockerfiles:
             try:

--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -18,7 +18,6 @@ USER harambe
 # Note: Python3.12 supports subclassing pathlib.Path
 class BasePath(Path):
     _flavour = type(Path())._flavour
-    _parse_args = type(Path())._parse_args
 
 
 class FilePath(BasePath):

--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -17,7 +17,7 @@ USER harambe
 
 # Note: Python3.12 supports subclassing pathlib.Path
 class BasePath(Path):
-    _flavour = type(Path())._flavour
+    _flavour = type(Path())._flavour  # type: ignore
 
 
 class FilePath(BasePath):

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -1,7 +1,5 @@
 import asyncio
 import os
-import shlex
-import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -148,7 +148,8 @@ def build(generate, path):
         ):
             raise FileNotFoundError(
                 f"The bots directory '{path}', 'bot/' and 'bot.py' does not exist in your path. "
-                f"You should have a '{path}/' or 'bot/' folder, or a 'bot.py' file in the root of your project."
+                f"You should have a '{path}/' or 'bot/' folder, or a 'bot.py' file in the root "
+                "of your project."
             )
         if path.is_file():
             dockerfile_content = DOCKERFILE_CONTENT

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -159,35 +159,34 @@ def build(generate, path):
             docker_filename = f"Dockerfile.{path.parent.name}-bot"
             dockerfile_content += f"COPY {path.name}/ /app/bot\n"
             _build_helper(docker_filename, dockerfile_content)
-            return
 
-        files = sorted({file for file in path.iterdir() if file.is_file()}, reverse=True)
-        bots = []
-        for file in files:
-            if file.name == "__init__.py" or file.name == "bot.py":
-                bots = [file]
-                break
-            bots.append(file)
-        for bot in bots:
-            dockerfile_content = DOCKERFILE_CONTENT
-            if (Path.cwd() / "requirements.txt").exists():
-                dockerfile_content += "COPY requirements.txt .\n"
-                dockerfile_content += (
-                    "RUN pip install --upgrade pip && pip install -r requirements.txt\n"
-                )
+        else:
+            files = sorted({file for file in path.iterdir() if file.is_file()}, reverse=True)
+            bots = []
+            for file in files:
+                if file.name == "__init__.py" or file.name == "bot.py":
+                    bots = [file]
+                    break
+                bots.append(file)
+            for bot in bots:
+                dockerfile_content = DOCKERFILE_CONTENT
+                if (Path.cwd() / "requirements.txt").exists():
+                    dockerfile_content += "COPY requirements.txt .\n"
+                    dockerfile_content += (
+                        "RUN pip install --upgrade pip && pip install -r requirements.txt\n"
+                    )
 
-            if (Path.cwd() / "ape-config.yaml").exists():
-                dockerfile_content += "COPY ape-config.yaml .\n"
-                dockerfile_content += "RUN ape plugins install -U .\n"
+                if (Path.cwd() / "ape-config.yaml").exists():
+                    dockerfile_content += "COPY ape-config.yaml .\n"
+                    dockerfile_content += "RUN ape plugins install -U .\n"
 
-            if bot.name == "__init__.py" or bot.name == "bot.py":
-                docker_filename = f"Dockerfile.{bot.parent.parent.name}-bot"
-                dockerfile_content += f"COPY {path.name}/ /app/bot\n"
-            else:
-                docker_filename = f"Dockerfile.{bot.name.replace('.py', '')}-bot"
-                dockerfile_content += f"COPY {path.name}/{bot.name} /app/bot.py\n"
-            _build_helper(docker_filename, dockerfile_content)
-        return
+                if bot.name == "__init__.py" or bot.name == "bot.py":
+                    docker_filename = f"Dockerfile.{bot.parent.parent.name}-bot"
+                    dockerfile_content += f"COPY {path.name}/ /app/bot\n"
+                else:
+                    docker_filename = f"Dockerfile.{bot.name.replace('.py', '')}"
+                    dockerfile_content += f"COPY {path.name}/{bot.name} /app/bot.py\n"
+                _build_helper(docker_filename, dockerfile_content)
 
     if not (path := Path.cwd() / ".silverback-images").exists():
         raise FileNotFoundError(

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -19,7 +19,7 @@ from ape.contracts import ContractInstance
 from ape.exceptions import Abort, ApeException
 from fief_client.integrations.cli import FiefAuth
 
-from silverback._build_utils import generate_dockerfiles, generate_docker_images
+from silverback._build_utils import generate_docker_images, generate_dockerfiles
 from silverback._click_ext import (
     SectionedHelpGroup,
     auth_required,

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -205,7 +205,7 @@ def build(generate, path):
             result = subprocess.run(
                 command,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
                 text=True,
                 check=True,
             )

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -150,7 +150,9 @@ def build(generate, path):
             dockerfile_content = DOCKERFILE_CONTENT
             if (Path.cwd() / "requirements.txt").exists():
                 dockerfile_content += "COPY requirements.txt .\n"
-                dockerfile_content += "RUN pip install --upgrade pip && pip install -r requirements.txt\n"
+                dockerfile_content += (
+                    "RUN pip install --upgrade pip && pip install -r requirements.txt\n"
+                )
 
             if (Path.cwd() / "ape-config.yaml").exists():
                 dockerfile_content += "COPY ape-config.yaml .\n"

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -135,14 +135,17 @@ def build_helper(docker_fn: str, dockerfile_c: str):
     click.echo(f"Generated {dockerfile_path}")
 
 
-
 @cli.command(section="Local Commands")
 @click.option("--generate", is_flag=True, default=False)
 @click.argument("path", required=False, type=str, default="bots")
 def build(generate, path):
     """Generate Dockerfiles and build bot images"""
     if generate:
-        if not (path := Path.cwd() / path).exists() and not (path := Path.cwd() / "bot").exists() and not (path := Path.cwd() / "bot.py").exists():
+        if (
+            not (path := Path.cwd() / path).exists()
+            and not (path := Path.cwd() / "bot").exists()
+            and not (path := Path.cwd() / "bot.py").exists()
+        ):
             raise FileNotFoundError(
                 f"The bots directory '{path}', 'bot/' and 'bot.py' does not exist in your path. "
                 f"You should have a '{path}/' or 'bot/' folder, or a 'bot.py' file in the root of your project."

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -19,7 +19,7 @@ from ape.contracts import ContractInstance
 from ape.exceptions import Abort, ApeException
 from fief_client.integrations.cli import FiefAuth
 
-from silverback._build_utils import generate_dockerfiles
+from silverback._build_utils import generate_dockerfiles, generate_docker_images
 from silverback._click_ext import (
     SectionedHelpGroup,
     auth_required,
@@ -144,26 +144,8 @@ def build(generate, path):
             f"The dockerfile directory '{path}' does not exist. "
             "You should have a `{path}/` folder in the root of your project."
         )
-    dockerfiles = {file for file in path.iterdir() if file.is_file()}
-    for file in dockerfiles:
-        try:
-            command = shlex.split(
-                "docker build -f "
-                f"./{file.parent.name}/{file.name} "
-                f"-t {file.name.split('.')[1]}:latest ."
-            )
-            result = subprocess.run(
-                command,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                check=True,
-            )
-            click.echo(result.stdout)
-        except subprocess.CalledProcessError as e:
-            click.echo("Error during docker build:")
-            click.echo(e.stderr)
-            raise
+
+    generate_docker_images(path)
 
 
 @cli.command(cls=ConnectedProviderCommand, section="Local Commands")

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -128,21 +128,36 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, bot):
     asyncio.run(runner.run())
 
 
+def build_helper(docker_fn: str, dockerfile_c: str):
+    dockerfile_path = Path.cwd() / ".silverback-images" / docker_fn
+    dockerfile_path.parent.mkdir(exist_ok=True)
+    dockerfile_path.write_text(dockerfile_c.strip() + "\n")
+    click.echo(f"Generated {dockerfile_path}")
+
+
+
 @cli.command(section="Local Commands")
 @click.option("--generate", is_flag=True, default=False)
 @click.argument("path", required=False, type=str, default="bots")
 def build(generate, path):
     """Generate Dockerfiles and build bot images"""
     if generate:
-        if not (path := Path.cwd() / path).exists():
+        if not (path := Path.cwd() / path).exists() and not (path := Path.cwd() / "bot").exists() and not (path := Path.cwd() / "bot.py").exists():
             raise FileNotFoundError(
-                f"The bots directory '{path}' does not exist. "
-                "You should have a `{path}/` folder in the root of your project."
+                f"The bots directory '{path}', 'bot/' and 'bot.py' does not exist in your path. "
+                f"You should have a '{path}/' or 'bot/' folder, or a 'bot.py' file in the root of your project."
             )
-        files = {file for file in path.iterdir() if file.is_file()}
+        if path.is_file():
+            dockerfile_content = DOCKERFILE_CONTENT
+            docker_filename = f"Dockerfile.{path.parent.name}-bot"
+            dockerfile_content += f"COPY {path.name}/ /app/bot\n"
+            build_helper(docker_filename, dockerfile_content)
+            return
+
+        files = sorted({file for file in path.iterdir() if file.is_file()}, reverse=True)
         bots = []
         for file in files:
-            if "__init__" in file.name:
+            if file.name == "__init__.py" or file.name == "bot.py":
                 bots = [file]
                 break
             bots.append(file)
@@ -158,16 +173,13 @@ def build(generate, path):
                 dockerfile_content += "COPY ape-config.yaml .\n"
                 dockerfile_content += "RUN ape plugins install -U .\n"
 
-            if "__init__" in bot.name:
-                docker_filename = f"Dockerfile.{bot.parent.name}"
+            if bot.name == "__init__.py" or bot.name == "bot.py":
+                docker_filename = f"Dockerfile.{bot.parent.parent.name}-bot"
                 dockerfile_content += f"COPY {path.name}/ /app/bot\n"
             else:
-                docker_filename = f"Dockerfile.{bot.name.replace('.py', '')}"
+                docker_filename = f"Dockerfile.{bot.name.replace('.py', '')}-bot"
                 dockerfile_content += f"COPY {path.name}/{bot.name} /app/bot.py\n"
-            dockerfile_path = Path.cwd() / ".silverback-images" / docker_filename
-            dockerfile_path.parent.mkdir(exist_ok=True)
-            dockerfile_path.write_text(dockerfile_content.strip() + "\n")
-            click.echo(f"Generated {dockerfile_path}")
+            build_helper(docker_filename, dockerfile_content)
         return
 
     if not (path := Path.cwd() / ".silverback-images").exists():

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -17,7 +17,7 @@ from ape.contracts import ContractInstance
 from ape.exceptions import Abort, ApeException
 from fief_client.integrations.cli import FiefAuth
 
-from silverback._build_utils import generate_docker_images, generate_dockerfiles
+from silverback._build_utils import build_docker_images, generate_dockerfiles
 from silverback._click_ext import (
     SectionedHelpGroup,
     auth_required,
@@ -143,7 +143,7 @@ def build(generate, path):
             "You should have a `{path}/` folder in the root of your project."
         )
 
-    generate_docker_images(path)
+    build_docker_images(path)
 
 
 @cli.command(cls=ConnectedProviderCommand, section="Local Commands")


### PR DESCRIPTION
### What I did

Added a check for `requirements.txt` and `ape-config.yaml` so `silverback build` doesn't fail if those files don't exist

fixes: #150 

### How I did it

Removed the lines pertaining to the `requirements.txt` and `ape-config.yaml` files and move them into a conditional within the build command.

### How to verify it

```
python3 -m venv venv
pip install <this pr>
cd /to/a/silverback/directory/project
sivlerback build --generate
```
Check your dockerfile output in .silverback-images
```
mv requirements.txt req.txt

or if that file didn't exist

touch requirements.txt

silverback build --generate
```
Check your dockerfile output in .silverback-images and the requirements.txt lines should no longer be there.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
