### PR TITLE
feat(worker): add SILVERBACK_FORK_MODE handler execution context

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,0 +1,4 @@
+# Ensure we are configured for fork mode correct for example
+ethereum:
+  mainnet-fork:
+    default_provider: foundry

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -28,6 +28,10 @@ class Settings(BaseSettings, ManagerAccessMixin):
     # A unique identifier for this silverback instance
     BOT_NAME: str = "bot"
 
+    # Execute every handler using an independent fork context
+    # NOTE: Requires fork-able provider installed and configured for network
+    FORK_MODE: bool = False
+
     BROKER_CLASS: str = "taskiq:InMemoryBroker"
     BROKER_URI: str = ""  # To be deprecated in 0.6
     BROKER_KWARGS: dict[str, Any] = dict()


### PR DESCRIPTION
### What I did

This PR adds a settings mode to silverback to trigger every single registered handler (through the default registration interface) using a fork context (e.g. `with ape.networks.fork(): ...`). This potentially unblocks the `BacktestRunner` and `silverback test` by allowing all tests to execute within a fork context off of historical state

### How I did it

depends: https://github.com/ApeWorX/ape/pull/2349

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
