### PR TITLE
perf: make silverback --help faster

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 100
+ignore = E704,W503,PYD002
 exclude =
 	venv*
 	.eggs

--- a/silverback/__init__.py
+++ b/silverback/__init__.py
@@ -1,6 +1,24 @@
-from .exceptions import CircuitBreaker, SilverbackException
-from .main import SilverbackBot
-from .state import StateSnapshot
+def __getattr__(name: str):
+    if name == "CircuitBreaker":
+        from .exceptions import CircuitBreaker
+
+        return CircuitBreaker
+
+    elif name == "SilverbackException":
+        from .exceptions import SilverbackException
+
+        return SilverbackException
+
+    elif name == "SilverbackBot":
+        from .main import SilverbackBot
+
+        return SilverbackBot
+
+    elif name == "StateSnapshot":
+        from .state import StateSnapshot
+
+        return StateSnapshot
+
 
 __all__ = [
     "StateSnapshot",


### PR DESCRIPTION
### What I did

Cuts the time down. It is twice as fast for me now to run `silverback --help`.

### How I did it

* Any CLI module has to be more careful on its top-level imports
* Root init file of package needs to also be careful, using a `__getattr__` there.

### How to verify it

```sh
time silverback --help
```


Before:

```
silverback  4.13s user 0.83s system 93% cpu 5.280 total
```

After:

```
silverback  1.63s user 0.28s system 83% cpu 2.297 total
```

Results may vary.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
