### PR TITLE
fix: raise UsageError

### DIFF
--- a/silverback/cluster/client.py
+++ b/silverback/cluster/client.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from functools import cache
 from typing import ClassVar, Literal
 
+import click
 import httpx
 from ape import Contract
 from ape.contracts import ContractInstance
@@ -54,7 +55,7 @@ def handle_error_with_response(response: httpx.Response):
             else:
                 message = response.text
 
-        raise RuntimeError(message)
+        raise click.UsageError(message)
 
     response.raise_for_status()
 

--- a/silverback/cluster/client.py
+++ b/silverback/cluster/client.py
@@ -9,9 +9,9 @@ from ape.logging import LogLevel
 from apepay import Stream, StreamManager
 from pydantic import computed_field
 
+from silverback.exceptions import ClientError
 from silverback.version import version
 
-from .exceptions import ClientError
 from .types import (
     BotHealth,
     BotInfo,

--- a/silverback/cluster/client.py
+++ b/silverback/cluster/client.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from functools import cache
 from typing import ClassVar, Literal
 
-import click
 import httpx
 from ape import Contract
 from ape.contracts import ContractInstance
@@ -12,6 +11,7 @@ from pydantic import computed_field
 
 from silverback.version import version
 
+from .exceptions import ClientError
 from .types import (
     BotHealth,
     BotInfo,
@@ -55,7 +55,7 @@ def handle_error_with_response(response: httpx.Response):
             else:
                 message = response.text
 
-        raise click.UsageError(message)
+        raise ClientError(message)
 
     response.raise_for_status()
 

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import click
 from ape.exceptions import ApeException
 
 from .types import TaskType
@@ -39,6 +40,10 @@ class StartupFailure(SilverbackException):
             super().__init__(f"Startup failure(s):\n{error_str}")
         else:
             super().__init__("Startup failure(s) detected. See logs for details.")
+
+
+class ClientError(SilverbackException, click.UsageError):
+    """Exception for client errors in the HTTP request."""
 
 
 class NoTasksAvailableError(SilverbackException):

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -42,6 +42,7 @@ class StartupFailure(SilverbackException):
             super().__init__("Startup failure(s) detected. See logs for details.")
 
 
+# NOTE: Subclass `click.UsageError` here so bad requests in CLI don't show stack trace
 class ClientError(SilverbackException, click.UsageError):
     """Exception for client errors in the HTTP request."""
 


### PR DESCRIPTION
### What I did
Http failure in client code should catch and re-raise those issues as `click.UsageError` exceptions instead of `RuntimeError`
<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
