### PR TITLE
refactor(cli): new cluster and workspaces

### DIFF
--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -244,13 +244,14 @@ def new_workspace(
     if not workspace_name:
         raise click.UsageError("Must provide a name or a slug/name combo")
 
-    platform.create_workspace(
+    workspace = platform.create_workspace(
         workspace_name=workspace_name,
         workspace_slug=workspace_slug,
     )
-    click.echo(f"{click.style('SUCCESS', fg='green')}: Created '{workspace_name}'")
-    click.echo(f"name: {workspace_name}")
-    click.echo(f"slug: {workspace_slug}")
+    click.echo(
+        f"{click.style('SUCCESS', fg='green')}: "
+        f"Created '{workspace.name}' (slug: '{workspace.slug}')"
+    )
 
 
 @workspaces.command(name="update", section="Platform Commands (https://silverback.apeworx.io)")
@@ -366,9 +367,9 @@ def new_cluster(
         cluster_name=cluster_name,
         cluster_slug=cluster_slug,
     )
-    click.echo(f"{click.style('SUCCESS', fg='green')}: Created '{cluster.name}'")
-    click.echo(f"name: {cluster_name}")
-    click.echo(f"slug: {cluster_slug}")
+    click.echo(
+        f"{click.style('SUCCESS', fg='green')}: Created '{cluster.name}' (slug: '{cluster.slug}')"
+    )
 
     if cluster.status == ResourceStatus.CREATED:
         click.echo(

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -31,7 +31,6 @@ from silverback._click_ext import (
 )
 from silverback.cluster.client import ClusterClient, PlatformClient
 from silverback.cluster.types import ClusterTier, LogLevel, ResourceStatus
-from silverback.exceptions import ClientError
 from silverback.runner import PollingRunner, WebsocketRunner
 from silverback.worker import run_worker
 
@@ -243,7 +242,7 @@ def new_workspace(
     )
 
     if not workspace_name:
-        raise ClientError("Must provide a name or a slug/name combo")
+        raise click.UsageError("Must provide a name or a slug/name combo")
 
     platform.create_workspace(
         workspace_name=workspace_name,
@@ -361,7 +360,7 @@ def new_cluster(
     )
 
     if not cluster_name:
-        raise ClientError("Must provide a name or a slug/name combo")
+        raise click.UsageError("Must provide a name or a slug/name combo")
 
     cluster = workspace_client.create_cluster(
         cluster_name=cluster_name,

--- a/silverback/cluster/client.py
+++ b/silverback/cluster/client.py
@@ -480,8 +480,8 @@ class PlatformClient(httpx.Client):
 
     def create_workspace(
         self,
-        workspace_slug: str = "",
-        workspace_name: str = "",
+        workspace_slug: str | None = None,
+        workspace_name: str | None = None,
     ) -> Workspace:
         response = self.post(
             "/workspaces",


### PR DESCRIPTION
### What I did
`New` commands for clusters and workspace weren't setting the missing name/slug if one was missing.
<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
