### PR TITLE
fix: ModuleNotFound on run cmd

### DIFF
--- a/silverback/_click_ext.py
+++ b/silverback/_click_ext.py
@@ -345,4 +345,11 @@ def bot_path_callback(ctx: click.Context, param: click.Parameter, path: str | No
     try:
         return import_from_string(path)
     except ImportFromStringError:
-        return import_from_string(f"bots.{path}")
+        try:
+            return import_from_string(f"bots.{path}")
+        except ModuleNotFoundError:
+            # This may happen if accidentally running `silverback run`
+            # with no bots arguments outside of your bots-project directory.
+            raise click.BadParameter(
+                "Nothing to run: No bot argument(s) given and no bots module found."
+            )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,4 @@
-def test_run(cli, runner):
+def test_run_no_bots(cli, runner):
     result = runner.invoke(cli, "run")
     assert result.exit_code != 0
     expected = (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,19 @@
+def test_run(cli, runner):
+    result = runner.invoke(cli, "run")
+    assert result.exit_code != 0
+    expected = (
+        "Usage: cli run [OPTIONS] [BOT]\n"
+        "Try 'cli run --help' for help.\n\n"
+        "Error: Invalid value for '[BOT]': "
+        "Nothing to run: No bot argument(s) given and no bots module found.\n"
+    )
+    assert result.output == expected
+
+
 def test_run_verbosity(cli, runner):
     """
     A test showing the verbosity option works.
     If it didn't work, the exit code would not be 0 here.
     """
-    result = runner.invoke(cli, ["run", "--help", "--verbosity", "DEBUG"])
+    result = runner.invoke(cli, ["run", "--help", "--verbosity", "DEBUG"], catch_exceptions=False)
     assert result.exit_code == 0


### PR DESCRIPTION
### What I did

Tried running `silverback run` in a random directory to see what happens. Got `ModuleNotFounder` error which I thought was kind of strange. I attempted to improve the experience there.

### How I did it

Another try and except and this time raise `click.BadParameter`

### How to verify it

Go to a random directory with no bots.
Run `silverback run`

Should see:

```
Usage: silverback run [OPTIONS] [BOT]
Try 'silverback run --help' for help.

Error: Invalid value for '[BOT]': Nothing ro run: No bot argument(s) given and no bots module found.
```

Is much better than it was.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
