### PR TITLE
refactor: simplify registry cli

### DIFF
--- a/docs/commands/cluster.rst
+++ b/docs/commands/cluster.rst
@@ -21,8 +21,8 @@ CLI commands for interacting with the Silverback Platform.
     :nested: full
     :commands: new, list, info, update, remove
 
-.. click:: silverback._cli:registry_auth
-    :prog: silverback cluster registry auth
+.. click:: silverback._cli:registry
+    :prog: silverback cluster registry
     :nested: full
     :commands: new, list, info, update, remove
 

--- a/docs/userguides/deploying.md
+++ b/docs/userguides/deploying.md
@@ -105,7 +105,7 @@ Once you have created all the Variable Group(s) that you need to operate your Bo
 ## Private Container Registries
 
 If you are using a private container registry to store your images, you will need to provide your bot with the necessary credentials to access it.
-First you will need to add your credentials to the cluster with the [`silverback cluster registry auth new`][silverback-cluster-registry-auth-new] command.
+First you will need to add your credentials to the cluster with the [`silverback cluster registry new`][silverback-cluster-registry-new] command.
 
 Then you can provide the name of these credentials when creating your bot with the [`silverback cluster bots new`][silverback-cluster-bots-new] or [`silverback cluster bots update`][silverback-cluster-bots-update] commands.
 
@@ -198,7 +198,7 @@ TODO: Downloading metrics from your Bot
 [silverback-cluster-bots-start]: ../commands/cluster.html#silverback-cluster-bots-start
 [silverback-cluster-bots-stop]: ../commands/cluster.html#silverback-cluster-bots-stop
 [silverback-cluster-bots-update]: ../commands/cluster.html#silverback-cluster-bots-update
-[silverback-cluster-registry-auth-new]: ../commands/cluster.html#silverback-cluster-registry-auth-new
+[silverback-cluster-registry-new]: ../commands/cluster.html#silverback-cluster-registry-new
 [silverback-cluster-vars]: ../commands/cluster.html#silverback-cluster-vars
 [silverback-cluster-vars-info]: ../commands/cluster.html#silverback-cluster-vars-info
 [silverback-cluster-vars-list]: ../commands/cluster.html#silverback-cluster-vars-list

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -784,12 +784,7 @@ def registry():
     """Manage container registry configuration"""
 
 
-@registry.group(cls=SectionedHelpGroup, name="auth")
-def registry_auth():
-    """Manage private container registry credentials"""
-
-
-@registry_auth.command(name="list")
+@registry.command(name="list")
 @cluster_client
 def credentials_list(cluster: "ClusterClient"):
     """List container registry credentials"""
@@ -801,7 +796,7 @@ def credentials_list(cluster: "ClusterClient"):
         click.secho("No registry credentials present in this cluster", bold=True, fg="red")
 
 
-@registry_auth.command(name="info")
+@registry.command(name="info")
 @click.argument("name")
 @cluster_client
 def credentials_info(cluster: "ClusterClient", name: str):
@@ -813,7 +808,7 @@ def credentials_info(cluster: "ClusterClient", name: str):
     click.echo(yaml.safe_dump(creds.model_dump(exclude={"id", "name"})))
 
 
-@registry_auth.command(name="new")
+@registry.command(name="new")
 @click.argument("name")
 @click.argument("registry")
 @cluster_client
@@ -831,7 +826,7 @@ def credentials_new(cluster: "ClusterClient", name: str, registry: str):
     click.echo(yaml.safe_dump(creds.model_dump(exclude={"id"})))
 
 
-@registry_auth.command(name="update")
+@registry.command(name="update")
 @click.argument("name")
 @click.option("-r", "--registry")
 @cluster_client
@@ -847,7 +842,7 @@ def credentials_update(cluster: "ClusterClient", name: str, registry: str | None
     click.echo(yaml.safe_dump(creds.model_dump(exclude={"id"})))
 
 
-@registry_auth.command(name="remove")
+@registry.command(name="remove")
 @click.argument("name")
 @cluster_client
 def credentials_remove(cluster: "ClusterClient", name: str):


### PR DESCRIPTION
### What I did
Simplified `registry auth` commands to just `registry` to make it easier for users to work with. 
<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
