### PR TITLE
fix: check bots by network

### DIFF
--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -1019,8 +1019,8 @@ def new_bot(
 ):
     """Create a new bot in a CLUSTER with the given configuration"""
 
-    if name in cluster.bots:
-        raise click.UsageError(f"Cannot use name '{name}' to create bot")
+    if name in cluster.bots_by_network(network=network):
+        raise click.UsageError(f"Bot name {name} already exists in network {network}.")
 
     vargroup = [group for group in vargroups]
 

--- a/silverback/cluster/client.py
+++ b/silverback/cluster/client.py
@@ -296,6 +296,11 @@ class ClusterClient(httpx.Client):
         handle_error_with_response(response)
         return {bot.name: bot for bot in map(Bot.model_validate, response.json())}
 
+    def bots_by_network(self, network: str) -> dict[str, Bot]:
+        response = self.get(f"/bots/network/{network}")
+        handle_error_with_response(response)
+        return {bot.name: bot for bot in map(Bot.model_validate, response.json())}
+
     def new_bot(
         self,
         name: str,


### PR DESCRIPTION
### What I did
Check if the bot name exists in network instead of checking if bot name exists in entire cluster.
<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
