### PR TITLE
fix(cluster): error when handling streaming response exception

### DIFF
--- a/silverback/cluster/client.py
+++ b/silverback/cluster/client.py
@@ -31,6 +31,9 @@ DEFAULT_HEADERS = {"User-Agent": f"Silverback SDK/{version}"}
 
 def handle_error_with_response(response: httpx.Response):
     if 400 <= response.status_code < 500:
+        # NOTE: Must call `response.read()` for for streaming request
+        # https://github.com/encode/httpx/discussions/1856#discussioncomment-1316674
+        response.read()
         message = response.text
 
         try:


### PR DESCRIPTION
### What I did

Currently, errors in streaming requests (basically just bot logs rn) will raise a different error due to misuse of the httpx API

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
