### PR TITLE
fix(cli): don't display VarGroupInfo.id (or .created)

### DIFF
--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -1109,7 +1109,9 @@ def bot_info(cluster: "ClusterClient", bot_name: str):
     click.echo(yaml.safe_dump(bot_dump))
     if bot.environment:
         click.echo("environment:")
-        click.echo(yaml.safe_dump([var.model_dump() for var in bot.vargroups]))
+        click.echo(
+            yaml.safe_dump([var.model_dump(exclude={"id", "created"}) for var in bot.vargroups])
+        )
 
 
 @bots.command(name="update", section="Configuration Commands")


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
