### PR TITLE
feat(runner): graceful shutdown and SIGINT/SIGTERM handling

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         "eth-pydantic-types",  # Use same version as eth-ape
         "packaging",  # Use same version as eth-ape
         "pydantic_settings",  # Use same version as eth-ape
+        "quattro>=25.2,<26",  # Manage task groups and background tasks
         "taskiq[metrics]>=0.11.9,<0.12",
         "tomlkit>=0.12,<1",  # For reading/writing global platform profile
         "fief-client[cli]>=0.19,<1",  # for platform auth/cluster login

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -105,8 +105,9 @@ def _network_callback(ctx, param, val):
     callback=cls_import_callback,
 )
 @click.option("-x", "--max-exceptions", type=int, default=3)
+@click.option("--debug", is_flag=True, default=False)
 @click.argument("bot", required=False, callback=bot_path_callback)
-def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, bot):
+def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, debug, bot):
     """Run Silverback bot"""
     from silverback.runner import PollingRunner, WebsocketRunner
 
@@ -127,7 +128,7 @@ def run(cli_ctx, account, runner_class, recorder_class, max_exceptions, bot):
         recorder=recorder_class() if recorder_class else None,
         max_exceptions=max_exceptions,
     )
-    asyncio.run(runner.run())
+    asyncio.run(runner.run(), debug=debug)
 
 
 @cli.command(section="Local Commands")
@@ -169,12 +170,16 @@ def build(generate, path):
 @click.option("-w", "--workers", type=int, default=2)
 @click.option("-x", "--max-exceptions", type=int, default=3)
 @click.option("-s", "--shutdown_timeout", type=int, default=90)
+@click.option("--debug", is_flag=True, default=False)
 @click.argument("bot", required=False, callback=bot_path_callback)
-def worker(cli_ctx, account, workers, max_exceptions, shutdown_timeout, bot):
+def worker(cli_ctx, account, workers, max_exceptions, shutdown_timeout, debug, bot):
     """Run Silverback task workers (advanced)"""
     from silverback.worker import run_worker
 
-    asyncio.run(run_worker(bot.broker, worker_count=workers, shutdown_timeout=shutdown_timeout))
+    asyncio.run(
+        run_worker(bot.broker, worker_count=workers, shutdown_timeout=shutdown_timeout),
+        debug=debug,
+    )
 
 
 @cli.command(section="Cloud Commands (https://silverback.apeworx.io)")

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -342,8 +342,14 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
                     web3.subscription_manager.handle_subscriptions(run_forever=True)
                 )
 
+            # NOTE: This triggers daemon tasks
             await super().run(*runtime_tasks, run_subscriptions)
-            await web3.subscription_manager.unsubscribe_all()
+            try:
+                # TODO: ctrl+C raises `websockets.exceptions.ConnectionClosedError`
+                await web3.subscription_manager.unsubscribe_all()
+            except Exception as e:
+                # NOTE: We don't really need to see any errors from here
+                logger.debug(str(e))
 
 
 class PollingRunner(BaseRunner, ManagerAccessMixin):

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -154,14 +154,10 @@ class BaseRunner(ABC):
         # Load the snapshot (if available)
         # NOTE: Add some additional handling to see if this feature is available in bot
         if TaskType.SYSTEM_LOAD_SNAPSHOT not in supported_task_types:
-            logger.warning(
+            raise StartupFailure(
                 "Silverback no longer supports runner-based snapshotting, "
                 "please upgrade your bot SDK version to latest to use snapshots."
             )
-            startup_state: StateSnapshot | None = StateSnapshot(
-                last_block_seen=-1,
-                last_block_processed=-1,
-            )  # Use empty snapshot
 
         elif not (startup_state := await self.datastore.init(self.bot.identifier)):
             logger.warning("No state snapshot detected, using empty snapshot")

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -1,4 +1,6 @@
 import asyncio
+import signal
+import sys
 from abc import ABC, abstractmethod
 from typing import Any, Callable
 
@@ -122,6 +124,16 @@ class BaseRunner(ABC):
             :class:`~silverback.exceptions.NoTasksAvailableError`:
                 If there are no configured tasks to execute.
         """
+
+        def exit_handler(signum, _frame):
+            logger.info(f"{signal.Signals(signum).name} signal received")
+            sys.exit(0)  # Exit normally
+
+        # NOTE: Make sure we handle various ways that OS might kill process
+        signal.signal(signal.SIGTERM, exit_handler)
+        # NOTE: Overwrite Ape's default signal handler (causes issues)
+        signal.signal(signal.SIGINT, exit_handler)
+
         # Initialize broker (run worker startup events)
         await self.bot.broker.startup()
 


### PR DESCRIPTION
### What I did

Quattro has a Python 3.10+ compatible implementation of TaskGroups (which is 3.11+), and some other nicer API for working with some asyncio functions (such as gather) using TaskGroups where we should get more stable error messages on internal failures (i.e. no leakage of internal tasks failing)

fixes: #67
fixes SBK-428

### How I did it

- Refactored much of the internals of `BaseRunner.run` to use `quattro.gather`
- Override Ape's signal handler to work w/ k8s and `KeyboardInterrupt`

### How to verify it

Start the example and `KeyboardInterrupt` at various places during startup/runtime. Also wait long enough for `CircuitBreaker` to naturally trigger shutdown during task exec

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
