### PR TITLE
fix: allow `ContractEventWrapper` to be used as a task container

### DIFF
--- a/silverback/main.py
+++ b/silverback/main.py
@@ -298,7 +298,7 @@ class SilverbackBot(ManagerAccessMixin):
         elif container and isinstance(container, ContractEventWrapper):
             if len(container.events) != 1:
                 raise InvalidContainerTypeError(
-                    f"Cannot use {container} as it contains multiple event definitions"
+                    f"Requires exactly 1 event to unwrap: {container.events}"
                 )
             container = container.events[0]
 

--- a/silverback/main.py
+++ b/silverback/main.py
@@ -6,7 +6,7 @@ from functools import wraps
 from typing import Any, Awaitable, Callable
 
 from ape.api.networks import LOCAL_NETWORK_NAME
-from ape.contracts import ContractEvent, ContractInstance
+from ape.contracts import ContractEvent, ContractEventWrapper, ContractInstance
 from ape.logging import logger
 from ape.managers.chain import BlockContainer
 from ape.utils import ManagerAccessMixin
@@ -255,7 +255,7 @@ class SilverbackBot(ManagerAccessMixin):
     def broker_task_decorator(
         self,
         task_type: TaskType,
-        container: BlockContainer | ContractEvent | None = None,
+        container: BlockContainer | ContractEvent | ContractEventWrapper | None = None,
     ) -> Callable[[Callable], AsyncTaskiqDecoratedTask]:
         """
         Dynamically create a new broker task that handles tasks of ``task_type``.
@@ -280,7 +280,10 @@ class SilverbackBot(ManagerAccessMixin):
         """
         if (
             (task_type is TaskType.NEW_BLOCK and not isinstance(container, BlockContainer))
-            or (task_type is TaskType.EVENT_LOG and not isinstance(container, ContractEvent))
+            or (
+                task_type is TaskType.EVENT_LOG
+                and not isinstance(container, (ContractEvent, ContractEventWrapper))
+            )
             or (
                 task_type
                 not in (
@@ -291,6 +294,13 @@ class SilverbackBot(ManagerAccessMixin):
             )
         ):
             raise ContainerTypeMismatchError(task_type, container)
+
+        elif container and isinstance(container, ContractEventWrapper):
+            if len(container.events) != 1:
+                raise InvalidContainerTypeError(
+                    f"Cannot use {container} as it contains multiple event definitions"
+                )
+            container = container.events[0]
 
         # Register user function as task handler with our broker
         def add_taskiq_task(


### PR DESCRIPTION
### What I did

I am not sure why, but in some instances I was getting "Invalid container type" for using `ape.contracts.base.ContractEventWrapper`, even though I am not sure how it ended up that way:

```py
...
  File "/app/bot.py", line 104, in <module>
    @sm.on_stream_funded(bot)
     ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/apepay/manager.py", line 226, in decorator
    @app.on_(container)
     ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/silverback/main.py", line 446, in on_
    raise InvalidContainerTypeError(container)
silverback.exceptions.InvalidContainerTypeError: Invalid container type: <class 'ape.contracts.base.ContractEventWrapper'>
```

(From this line: https://github.com/ApeWorX/ApePay/blob/main/sdk/py/apepay/manager.py#L264)

### How I did it

I just handled the issue in brute-force way by raising if I couldn't properly reduce it down to a regular `ape.contracts.base.ContractEvent` type

### How to verify it

I need this released before I can test it, I haven't been able to verify the original issue locally yet, only in the cluster

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
