### PR TITLE
refactor(cluster): update broker plugin for cluster use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ COPY --from=builder /wheels/*.whl /wheels
 RUN pip install --upgrade pip \
     && pip install \
     --no-cache-dir --find-links=/wheels \
-    'taskiq-sqs>=0.0.11' \
-    'taskiq-redis>=1.0.2,<2' \
+    'taskiq-aio-pika>=0.4.1' \
+    'taskiq-redis>=1.0.4,<2' \
     /wheels/silverback-*.whl
 
 USER harambe

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
         "packaging",  # Use same version as eth-ape
         "pydantic_settings",  # Use same version as eth-ape
         "quattro>=25.2,<26",  # Manage task groups and background tasks
-        "taskiq[metrics]>=0.11.9,<0.12",
+        "taskiq[metrics]>=0.11.16,<0.12",
         "tomlkit>=0.12,<1",  # For reading/writing global platform profile
         "fief-client[cli]>=0.19,<1",  # for platform auth/cluster login
         "web3>=7.7,<8",  # TODO: Remove when Ape v0.9 is released (Ape v0.8 allows web3 v6)


### PR DESCRIPTION
### What I did

We no longer use `taskiq-sqs` for cloud use, so build it using the correct plugin

Also updates the base pin for taskiq

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
