### PR TITLE
fix: taskiq tries to set an illegal attribute of our system task methods

### DIFF
--- a/silverback/main.py
+++ b/silverback/main.py
@@ -2,7 +2,7 @@ import atexit
 import inspect
 from collections import defaultdict
 from datetime import timedelta
-from functools import wraps
+from functools import update_wrapper, wraps
 from typing import Any, Awaitable, Callable
 
 from ape.api.networks import LOCAL_NETWORK_NAME
@@ -182,7 +182,9 @@ class SilverbackBot(ManagerAccessMixin):
         assert str(task_type).startswith("system:"), "Can only add system tasks"
         # NOTE: This has to be registered with the broker in the worker
         return self.broker.register_task(
-            task_handler,
+            # NOTE: We need this as `.register_task` tries to update `.__name__` of `task_handler`,
+            #       but it is a method not a function (`update_wrapper` transforms it into one)
+            update_wrapper(lambda *args, **kwargs: task_handler(*args, **kwargs), task_handler),
             # NOTE: Name makes it impossible to conflict with user's handler fn names
             task_name=str(task_type),
             task_type=str(task_type),


### PR DESCRIPTION
### What I did

Due to a change in the upstream `taskiq` library (released as of 0.11.15), it will attempt to set the value of our system task handler methods `__name__` attribute to another name, which raises an attribute error because methods objects do not allow this
https://github.com/taskiq-python/taskiq/commit/181ff66bee8591a4125d6e2d76604c6dac88058c#diff-f68482a4dddb444455567415d93267303fc5c17b238fd4f2a1e0cc12a654380aR60-R90

### How I did it

Hack for a hack

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
