### PR TITLE
fix: accidentally polling logs from entire range of history

### DIFF
--- a/bots/example.py
+++ b/bots/example.py
@@ -64,9 +64,9 @@ def exec_block(block: BlockAPI, context: Annotated[Context, TaskiqDepends()]):
     return len(block.transactions)
 
 
-# This is how we trigger off of events
-# Set new_block_timeout to adjust the expected block time.
-@bot.on_(USDC.Transfer, start_block=19784367, new_block_timeout=25)
+# This is how we trigger off of events including logs from previous blocks
+# NOTE: Set new_block_timeout to adjust the expected block time.
+@bot.on_(USDC.Transfer, start_block=-10, new_block_timeout=25)
 # NOTE: Typing isn't required, it will still be an Ape `ContractLog` type
 def exec_event1(log):
     if log.log_index % 7 == 3:

--- a/silverback/main.py
+++ b/silverback/main.py
@@ -297,7 +297,7 @@ class SilverbackBot(ManagerAccessMixin):
         ):
             raise ContainerTypeMismatchError(task_type, container)
 
-        elif container and isinstance(container, ContractEventWrapper):
+        elif isinstance(container, ContractEventWrapper):
             if len(container.events) != 1:
                 raise InvalidContainerTypeError(
                     f"Requires exactly 1 event to unwrap: {container.events}"


### PR DESCRIPTION
### What I did

Checking "truthiness" of `ape.contracts.base.ContractEvent` object causes it to do `__len__` check to see if `len(event) == 0`, however this causes it to poll every single event log from every single block in a chain's history (obviously insane)

Ape should make an update to these objects to avoid polling entire chain history if a simple `if event` "truthiness" check is done

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
