### PR TITLE
chore(build): the example image needs the base image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -117,6 +117,8 @@ jobs:
           dry-run: true
 
   example:
+    # NOTE: We want the silverback image built above to base ours on
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
### What I did

Noticed that the build for the silverback example bot was hitting a bit of a race condition based on when a release happens

### How I did it

By depending on the build, the example should pick up the latest release as it's base

### How to verify it

Check build logs for release

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
