### PR TITLE
fix(build): also push example image on release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -130,7 +130,7 @@ jobs:
       - name: Build Examples
         uses: SilverbackLtd/build-action@v1
         with:
-            push: ${{ github.ref == 'refs/heads/main' }}
+            push: ${{ github.event_name != 'pull_request' }}
             tag: latest
             registry: ghcr.io
             username: ${{ github.actor }}


### PR DESCRIPTION
### What I did

Noticed that when we build on release, it wasn't actually pushing the latest example (which therefore isn't pulling in latest stable base image)

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
