### PR TITLE
feat: internal nonce tracking via `bot.nonce`

### DIFF
--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -13,7 +13,7 @@ There are 3 suggested ways to structure your project. In the root directory of y
 
 1. Create a `bot.py` file. This is the simplest way to define your bot project.
 
-2. Create a `bots/` folder. Then develop bots in this folder as separate scripts (Do not include a __init__.py file).
+2. Create a `bots/` folder. Then develop bots in this folder as separate scripts (Do not include a `__init__.py` file).
 
 3. Create a `bot/` folder with a `__init__.py` file that will include the instantiation of your `SilverbackBot()` object.
 
@@ -143,7 +143,7 @@ This function comes a parameter `state` that you can use for storing the results
 
 It's import to note that this is useful for ensuring that your workers (of which there can be multiple) have the resources necessary to properly handle any updates you want to make in your handler functions, such as connecting to the Telegram API, an SQL or NoSQL database connection, or something else. **This function will run on every worker process**.
 
-*New in 0.2.0*: These events moved from `on_startup()` and `on_shutdown()` for clarity.
+_New in 0.2.0_: These events moved from `on_startup()` and `on_shutdown()` for clarity.
 
 #### Worker State
 
@@ -180,7 +180,7 @@ def handle_on_shutdown():
     ...
 ```
 
-*Changed in 0.2.0*: The behavior of the `@bot.on_startup()` decorator and handler signature have changed. It is now executed only once upon bot startup and worker events have moved on `@bot.on_worker_startup()`.
+_Changed in 0.2.0_: The behavior of the `@bot.on_startup()` decorator and handler signature have changed. It is now executed only once upon bot startup and worker events have moved on `@bot.on_worker_startup()`.
 
 ## Bot State
 
@@ -229,6 +229,24 @@ To learn more about signing transactions with Ape, see the [documentation](https
 ```{warning}
 While not recommended, you can use keyfile accounts for automated signing.
 See [this guide](https://docs.apeworx.io/ape/stable/userguides/accounts.html#automation) to learn more about how to do that.
+```
+
+### Managing nonces
+
+Since Silverback allows handling many events in parallel, and thus can allow you to submit multiple transactions in a short timespan (in fact, prior to successful confirmation of previously broadcasted transactions), it may become vital to do "nonce management" in order to ensure that you are not producing transactions that might conflict with one another.
+The `bot.nonce` variable tracks the last-used nonce of the `bot.signer`, incrementing it every time a new transaction is signed _during the bot's operation_.
+By using this variable via `nonce=bot.nonce` in your transactions (instead of `bot.signer.nonce`, which is the default behavior when the `nonce=` transaction kwarg is omitted), you can ensure that you do not produce transactions with conflicting nonces, even at a very high rate of parallel transaction creation.
+
+```{note}
+The value of `bot.nonce` is the maximum between the internally-stored "last-used nonce", and the value given by RPC method
+```
+
+```{warning}
+Make sure to use an appropiate gas pricing algorithm in order to prevent your chain of multiple transactions from becoming "stuck" because an earlier broadcasted transaction was under-priced
+```
+
+```{warning}
+Do *not* use the same account on the same network at the same time as the one in use by your bot, as this could lead to extremely undesirable behavior, stuck transactions, or transaction failures/loss of funds
 ```
 
 ## Running your Bot

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -47,11 +47,6 @@ class StartupFailure(SilverbackException):
             super().__init__("Startup failure(s) detected. See logs for details.")
 
 
-# NOTE: Subclass `click.UsageError` here so bad requests in CLI don't show stack trace
-class ClientError(SilverbackException, click.UsageError):
-    """Exception for client errors in the HTTP request."""
-
-
 class NoTasksAvailableError(SilverbackException):
     def __init__(self):
         super().__init__("No tasks to execute")
@@ -67,3 +62,9 @@ class CircuitBreaker(Halt):
 
     def __init__(self, message: str):
         super(SilverbackException, self).__init__(message)
+
+
+# For Silverback Cluster client commands (CLI)
+# NOTE: Subclass `click.UsageError` here so bad requests in CLI don't show stack trace
+class ClientError(SilverbackException, click.UsageError):
+    """Exception for client errors in the HTTP request."""

--- a/silverback/exceptions.py
+++ b/silverback/exceptions.py
@@ -36,6 +36,13 @@ class SilverbackException(ApeException):
     """Base Exception for any Silverback runtime faults."""
 
 
+class NoSignerLoaded(SilverbackException):
+    def __init__(self):
+        super().__init__(
+            "No signer was made available. Please check config (e.g. `SILVERBACK_SIGNER_ALIAS=...`)"
+        )
+
+
 # TODO: `ExceptionGroup` added in Python 3.11
 class StartupFailure(SilverbackException):
     def __init__(self, *exceptions: BaseException | str | None):

--- a/silverback/main.py
+++ b/silverback/main.py
@@ -3,6 +3,7 @@ import inspect
 from collections import defaultdict
 from datetime import timedelta
 from functools import wraps
+from types import MethodType
 from typing import Any, Awaitable, Callable
 
 from ape.api.networks import LOCAL_NETWORK_NAME
@@ -14,7 +15,7 @@ from packaging.version import Version
 from pydantic import BaseModel
 from taskiq import AsyncTaskiqDecoratedTask, TaskiqEvents
 
-from .exceptions import ContainerTypeMismatchError, InvalidContainerTypeError
+from .exceptions import ContainerTypeMismatchError, InvalidContainerTypeError, NoSignerLoaded
 from .settings import Settings
 from .state import StateSnapshot
 from .types import SilverbackID, TaskType
@@ -142,6 +143,16 @@ class SilverbackBot(ManagerAccessMixin):
         atexit.register(provider_context.__exit__, None, None, None)
 
         self.signer = settings.get_signer()
+        if self.signer:
+            # NOTE: Monkeypatch `AccountAPI.call` to update bot nonce tracking state
+            original_call = self.signer.call
+
+            def call_override(account_instance, txn, *args, **kwargs):
+                self.state["system:last_nonce_used"] = txn.nonce
+                return original_call(txn, *args, **kwargs)
+
+            self.signer.__dict__["call"] = MethodType(call_override, self.signer)
+
         self.new_block_timeout = settings.NEW_BLOCK_TIMEOUT
         self.use_fork = settings.FORK_MODE and not self.provider.network.name.endswith("-fork")
 
@@ -225,6 +236,13 @@ class SilverbackBot(ManagerAccessMixin):
 
         self.state["system:last_block_seen"] = startup_state.last_block_seen
         self.state["system:last_block_processed"] = startup_state.last_block_processed
+
+        if self.signer:
+            # NOTE: 'BaseAddress.nonce` is 1 + last nonce that was used
+            self.state["system:last_nonce_used"] = max(
+                startup_state.last_nonce_used or -1, self.signer.nonce - 1
+            )
+
         # TODO: Load user custom state (should not start with `system:`)
 
     async def __create_snapshot_handler(

--- a/silverback/main.py
+++ b/silverback/main.py
@@ -261,6 +261,7 @@ class SilverbackBot(ManagerAccessMixin):
             # TODO: Migrate these to parameters (remove explicitly from state)
             last_block_seen=self.state.get("system:last_block_seen", -1),
             last_block_processed=self.state.get("system:last_block_processed", -1),
+            last_nonce_used=self.state.get("system:last_nonce_used"),
         )
 
     # To ensure we don't have too many forks at once
@@ -271,7 +272,7 @@ class SilverbackBot(ManagerAccessMixin):
         if not self.signer:
             raise NoSignerLoaded()
 
-        elif not (last_nonce_used := self.state["system:last_nonce_used"]):
+        elif (last_nonce_used := self.state.get("system:last_nonce_used")) is None:
             raise AttributeError(
                 "`bot.state` not fully loaded yet, please do not use during worker startup."
             )

--- a/silverback/state.py
+++ b/silverback/state.py
@@ -12,6 +12,11 @@ class StateSnapshot(BaseModel):
     # Last block number processed by a worker
     last_block_processed: int
 
+    # NOTE: Any new items we add here must have a default to be backwards-compatible
+
+    # Last nonce used by signer
+    last_nonce_used: int | None = None
+
     # Last time the state was updated
     # NOTE: intended to use default when creating a model with this type
     last_updated: UTCTimestamp = Field(default_factory=utc_now)


### PR DESCRIPTION
### What I did

This adds support for tracking and maintaining an internally-tracked nonce inside the `bot` class that supports concurrent use of transaction signing with the signing account

requires: #229

### How I did it

Added `last_nonce_used` to state snapshot feature, and exposed via `bot.nonce`

### How to verify it

Needs more real-time testing on a high-speed chain

Note that `bot.nonce` and `bot.signer.nonce` *will track separately* (the later is purely the RPC call to `eth_getNonce`)

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
