### PR TITLE
refactor!: migrate decoding to worker-side, run worker tasks in background

### DIFF
--- a/bots/example.py
+++ b/bots/example.py
@@ -99,12 +99,12 @@ def sample_metric(time: datetime):
     return random.random()
 
 
-@bot.on_(chain.blocks)
+@bot.cron("*/5 * * * *")
 # NOTE: You can have multiple handlers for any trigger we support
-def check_logs(log):
-    if bot.state.logs_processed > 20:
-        # If you ever want the bot to immediately shutdown under some scenario, raise this exception
-        raise CircuitBreaker("Oopsie!")
+def stop_running_now(time):
+    # If you ever want the bot to immediately shutdown under some scenario,
+    # raise this exception (or a subclass of it)
+    raise CircuitBreaker("Oopsie!")
 
 
 # A final job to execute on Silverback shutdown

--- a/bots/latency-test.py
+++ b/bots/latency-test.py
@@ -1,0 +1,93 @@
+"""
+This bot allows measuring the latency of a signing setup, by producing a stream of transactions
+where the block number is a self-transfer amount, which can be analyzed by comparing the length
+of time (in blocks) between the block number the transaction was mined in (`.block.number`), and
+the transfer amount. FOR TESTING USE ONLY on a public testnet.
+
+Overall task/txn lifecycle (not to scale):
+
+|------------------------------------------ total time ------------------------------------------|
+|<-- trigger block mined |------------- [other blocks] --------------| settlement block mined -->|
+|-- RPC --||----------- bot's response time ---------||------ RPC -----||----- tx in mempool ----|
+
+                                       |--- sign ---||-- tx broadcast --|
+        |-- runner send --|          |-- worker exec --|      |-- runner recv --|
+                         |-- broker --|               |-- RB --|
+                        |--------------- task time -------------||-- recording time --|
+
+You can measure this latency via the following scripts in Ape console:
+
+    >>> from datetime import datetime, timezone
+    >>> txs = account.history  # or `account.history[start_nonce:stop_nonce]`
+    # Block that triggered task to execute
+    >>> task_recv_block = [chain.blocks[tx.value // 10**10] for tx in txs]
+    # Block that settled signer transaction
+    >>> txn_conf_block = [tx.block for tx in txs]
+    # Time when transaction was created by worker
+    >>> txn_creation_time = [
+    ...     datetime.fromtimestamp(tx.value % 10**10, tz=timezone.utc)
+    ...     for tx in txs
+    ... ]
+    # Time between block that triggered transaction vs. broadcasting next one
+    >>> task_start_latency = [
+    ...     (txn_submit - recv_blk.datetime)
+    ...     for recv_blk, txn_submit
+    ...     in zip(task_recv_block, txn_creation_time)
+    ... ]
+    # Time between broadcasting txn and block being mined with txn in it
+    >>> broadcasted_task_metric = pd.DataFrame.fromdict()["broadcast"]
+    >>> txn_broadcast_latency = [
+    ...     (conf_blk.datetime - broadcasted)
+    ...     for conf_blk, broadcasted
+    ...     in zip(txn_conf_block, broadcasted_task_metric)
+    ... ]
+
+"""
+
+import os
+from datetime import datetime, timezone
+
+from ape import chain
+
+from silverback import SilverbackBot
+
+# NOTE: By default, assume this is a normal EOA (only 21k base gas required)
+GAS_LIMIT = int(os.environ.get("GAS_LIMIT", 21_000))
+MAX_EIP1559_BLOCK_DEPTH = int(os.environ.get("MAX_EIP1559_BLOCK_DEPTH", 3))
+PRIORITY_FEE = os.environ.get("PRIORITY_FEE", "0 gwei")
+
+bot = SilverbackBot()
+
+# NOTE: Requires a signer to run
+# NOTE: Don't run this on a mainnet
+assert bot.provider.network.name != "mainnet"
+
+
+def utc_now() -> float:
+    return datetime.now(timezone.utc).timestamp()
+
+
+@bot.on_(chain.blocks)
+async def broadcast(block) -> float:
+    # NOTE: Only use attributes of `block` that don't require RPC calls
+
+    # Sign and broadcast a transaction
+    bot.signer.transfer(
+        bot.signer,
+        # NOTE: Divide by 10**10 to obtain `block.number` from `txn.value`
+        #       (This allows easy display on most explorers)
+        # NOTE: Use `txn.value % 10**10` to obtain `start_time`
+        # NOTE: `int(utc_now())` strips sub-second timing from timestamp
+        f"0.{block.number:08}{int(utc_now())} ether",
+        nonce=bot.nonce,
+        # NOTE: all below txn kwargs skip unnecessary RPC calls to form txn
+        required_confirmations=0,  # NOTE: No need to wait for confirmation
+        gas_limit=GAS_LIMIT,  # NOTE: No need to estimate gas
+        # NOTE: assume EIP-1559 transactions are available
+        # NOTE: assume we are N blocks behind, w/ 12.5% max increase per block
+        base_fee=int(1.125**MAX_EIP1559_BLOCK_DEPTH * block.base_fee),
+        priority_fee=PRIORITY_FEE,
+    )
+
+    # This is the time at which the transaction has been successfully "broadcast"
+    return utc_now()

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -158,7 +158,7 @@ def build(generate, path):
                 "This command can auto-detect 'bot.py' or 'bot/' folder in project root"
                 ", or process all '*.py' bots in  'bots/' folder."
             )
-        print(path)
+
         generate_dockerfiles(path)
 
     if not (Path.cwd() / IMAGES_FOLDER_NAME).exists():

--- a/silverback/main.py
+++ b/silverback/main.py
@@ -257,9 +257,6 @@ class SilverbackBot(ManagerAccessMixin):
             last_nonce_used=self.state.get("system:last_nonce_used"),
         )
 
-    # To ensure we don't have too many forks at once
-    # HACK: Until `NetworkManager.fork` (and `ProviderContextManager`) allows concurrency
-
     @property
     def nonce(self) -> int:
         if not self.signer:
@@ -331,6 +328,9 @@ class SilverbackBot(ManagerAccessMixin):
             return result
 
         return ensure_log
+
+    # To ensure we don't have too many forks at once
+    # HACK: Until `NetworkManager.fork` (and `ProviderContextManager`) allows concurrency
 
     def _with_fork_decorator(self, handler: Callable) -> Callable:
         # Trigger worker-side handling using fork network by wrapping handler

--- a/silverback/main.py
+++ b/silverback/main.py
@@ -11,7 +11,9 @@ from ape.api.networks import LOCAL_NETWORK_NAME
 from ape.contracts import ContractEvent, ContractEventWrapper, ContractInstance
 from ape.logging import logger
 from ape.managers.chain import BlockContainer
+from ape.types import ContractLog
 from ape.utils import ManagerAccessMixin
+from eth_utils import keccak, to_hex
 from packaging.version import Version
 from pydantic import BaseModel
 from taskiq import AsyncTaskiqDecoratedTask, TaskiqEvents
@@ -20,6 +22,7 @@ from .exceptions import ContainerTypeMismatchError, InvalidContainerTypeError, N
 from .settings import Settings
 from .state import StateSnapshot
 from .types import SilverbackID, TaskType
+from .utils import encode_topics_to_string, parse_hexbytes_dict
 
 
 class SystemConfig(BaseModel):
@@ -34,7 +37,7 @@ class SystemConfig(BaseModel):
 class TaskData(BaseModel):
     # NOTE: Data we need to know how to call a task via kicker
     name: str  # Name of user function
-    labels: dict[str, Any]
+    labels: dict[str, str]
 
     # NOTE: Any other items here must have a default value
 
@@ -246,18 +249,7 @@ class SilverbackBot(ManagerAccessMixin):
 
         # TODO: Load user custom state (should not start with `system:`)
 
-    async def __create_snapshot_handler(
-        self,
-        last_block_seen: int | None = None,
-        last_block_processed: int | None = None,
-    ) -> StateSnapshot:
-        # Task that updates state checkpoints before/after every non-system runtime task/at shutdown
-        if last_block_seen is not None:
-            self.state["system:last_block_seen"] = last_block_seen
-
-        if last_block_processed is not None:
-            self.state["system:last_block_processed"] = last_block_processed
-
+    async def __create_snapshot_handler(self) -> StateSnapshot:
         return StateSnapshot(
             # TODO: Migrate these to parameters (remove explicitly from state)
             last_block_seen=self.state.get("system:last_block_seen", -1),
@@ -280,6 +272,65 @@ class SilverbackBot(ManagerAccessMixin):
 
         # NOTE: Next nonce (`.nonce` is meant to be used in next txn) is 1 + last
         return max(last_nonce_used + 1, self.signer.nonce)
+
+    def _checkpoint(
+        self,
+        last_block_seen: int | None = None,
+        last_block_processed: int | None = None,
+    ):
+        # Task that updates state checkpoints before/after every non-system runtime task/at shutdown
+        if last_block_seen is not None:
+            self.state["system:last_block_seen"] = last_block_seen
+
+        if last_block_processed is not None:
+            self.state["system:last_block_processed"] = last_block_processed
+
+    def _ensure_block(self, handler: Callable) -> Callable:
+        @wraps(handler)
+        async def ensure_block(block, *args, **kwargs):
+            # NOTE: With certain runners, `block` may be raw or in it's final form
+            if isinstance(block, dict):
+                block = self.provider.network.ecosystem.decode_block(parse_hexbytes_dict(block))
+
+            self._checkpoint(last_block_seen=block.number)
+            result = handler(block, *args, **kwargs)
+            self._checkpoint(last_block_processed=block.number)
+
+            if inspect.isawaitable(result):
+                return await result
+
+            return result
+
+        return ensure_block
+
+    def _ensure_log(self, event: ContractEvent, handler: Callable) -> Callable:
+        @wraps(handler)
+        async def ensure_log(log, *args, **kwargs):
+            # NOTE: With certain runners, `log` may be raw or in it's final form
+            if isinstance(log, dict):
+                if "event_arguments" in log:
+                    # This is an Ape object, simply initialize it
+                    log = ContractLog(**log)
+
+                else:  # This is a raw web3py object
+                    log = next(  # NOTE: `next` is okay since it only has one item
+                        self.provider.network.ecosystem.decode_logs(
+                            [parse_hexbytes_dict(log)], event.abi
+                        )
+                    )
+                    # TODO: Fix upstream w/ web3py
+                    log.transaction_hash = "0x" + log.transaction_hash.hex()
+
+            self._checkpoint(last_block_seen=log.block.number)
+            result = handler(log, *args, **kwargs)
+            self._checkpoint(last_block_processed=log.block.number)
+
+            if inspect.isawaitable(result):
+                return await result
+
+            return result
+
+        return ensure_log
 
     def _with_fork_decorator(self, handler: Callable) -> Callable:
         # Trigger worker-side handling using fork network by wrapping handler
@@ -352,20 +403,27 @@ class SilverbackBot(ManagerAccessMixin):
         def add_taskiq_task(
             handler: Callable[..., Any | Awaitable[Any]]
         ) -> AsyncTaskiqDecoratedTask:
-            labels = {"task_type": str(task_type)}
+            labels: dict[str, str] = dict()
 
-            # NOTE: Do *not* do `if container` because that does a `len(container)` call,
-            #       which for ContractEvent queries *every single log* ever emitted, and really
-            #       we only want to determine if it is not None
-            if container is not None and isinstance(container, ContractEvent):
-                # Address is almost a certainty if the container is being used as a filter here.
-                if not (contract_address := getattr(container.contract, "address", None)):
-                    raise InvalidContainerTypeError(
-                        "Please provide a contract event from a valid contract instance."
-                    )
+            if task_type is TaskType.NEW_BLOCK:
+                handler = self._ensure_block(handler)
 
-                labels["contract_address"] = contract_address
-                labels["event_signature"] = container.abi.signature
+            elif task_type is TaskType.EVENT_LOG:
+                assert container is not None and isinstance(container, ContractEvent)
+                # NOTE: allows broad capture filters (matching multiple addresses)
+                if contract_address := getattr(container.contract, "address", None):
+                    labels["address"] = contract_address
+                labels["event"] = container.abi.signature
+                labels["topics"] = encode_topics_to_string(
+                    [
+                        # Topic 0: event_id
+                        to_hex(keccak(text=container.abi.selector)),
+                        # Topic 1-4: event args ([..., ...] represent OR)
+                        # TODO: Add filter args
+                    ]
+                )
+
+                handler = self._ensure_log(container, handler)
 
             elif task_type is TaskType.CRON_JOB:
                 # NOTE: If cron schedule has never been true over a year timeframe, it's bad
@@ -386,6 +444,7 @@ class SilverbackBot(ManagerAccessMixin):
             return self.broker.register_task(
                 handler,
                 task_name=handler.__name__,
+                task_type=str(task_type),
                 **labels,
             )
 

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -1,13 +1,14 @@
-from typing import Any
+from collections import defaultdict
 
 from ape.logging import logger
-from ape.types import ContractLog
 from ape.utils import ManagerAccessMixin
-from eth_utils.conversions import to_hex
 from taskiq import TaskiqMessage, TaskiqMiddleware, TaskiqResult
 
 from silverback.types import TaskType
-from silverback.utils import hexbytes_dict
+
+IGNORE_LABELS: dict[TaskType, tuple[str, ...]] = defaultdict(tuple)
+IGNORE_LABELS[TaskType.EVENT_LOG] = ("event", "address", "topics")
+IGNORE_LABELS[TaskType.CRON_JOB] = ("cron",)
 
 
 class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
@@ -23,32 +24,12 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
 
         self.block_time = self.chain_manager.provider.network.block_time or compute_block_time()
 
-    def pre_send(self, message: TaskiqMessage) -> TaskiqMessage:
-        # TODO: Necessary because bytes/HexBytes doesn't encode/decode well for some reason
-        def fix_dict(data: dict, recurse_count: int = 0) -> dict:
-            fixed_data: dict[str, Any] = {}
-            for name, value in data.items():
-                if isinstance(value, bytes):
-                    fixed_data[name] = to_hex(value)
-                elif isinstance(value, dict):
-                    if recurse_count > 3:
-                        raise RecursionError("Event object is too deep")
-                    fixed_data[name] = fix_dict(value, recurse_count + 1)
-                else:
-                    fixed_data[name] = value
-
-            return fixed_data
-
-        message.args = [(fix_dict(arg) if isinstance(arg, dict) else arg) for arg in message.args]
-
-        return message
-
-    def _create_label(self, message: TaskiqMessage) -> str:
+    def _create_label(self, message: TaskiqMessage, task_type: TaskType) -> str:
         if labels_str := ",".join(
-            # NOTE: Have to add extra quotes around event signatures so they display as a string
-            f"{k}={v}" if k != "event_signature" else f'{k}="{v}"'
+            f"{k}={v}"
             for k, v in message.labels.items()
-            if k != "task_name"
+            # NOTE: Skip labels used for task processing
+            if k not in ("task_type", *IGNORE_LABELS[task_type])
         ):
             return f"{message.task_name}[{labels_str}]"
 
@@ -56,36 +37,28 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
             return message.task_name
 
     def pre_execute(self, message: TaskiqMessage) -> TaskiqMessage:
-        # NOTE: Ensure we always have this, no matter what
-        message.labels["task_name"] = message.task_name
+        if not (task_type_str := message.labels.get("task_type")):
+            # NOTE: Not a Silverback task unless it has this
+            return message
 
-        if "task_type" not in message.labels:
-            return message  # Not a silverback task
+        task_type = TaskType(task_type_str)
 
-        task_type_str = message.labels.pop("task_type")
-
-        try:
-            task_type = TaskType(task_type_str)
-        except ValueError:
-            return message  # Not a silverback task
-
-        # Add extra labels for our task to see what their source was
+        # Add labels for task logging based on task type
+        # NOTE: We choose labels that will help us track down offending data items
+        #       *without* fully doxxing more of _how_ the user is handling their data
         if task_type is TaskType.NEW_BLOCK:
-            # NOTE: Necessary because we don't know the exact block class
-            block = message.args[0] = self.provider.network.ecosystem.decode_block(
-                hexbytes_dict(message.args[0])
-            )
-            message.labels["block_number"] = str(block.number)
-            message.labels["block_hash"] = block.hash.hex()
+            block = message.args[0]
+            message.labels["block"] = block["hash"]
 
         elif task_type is TaskType.EVENT_LOG:
-            # NOTE: Just in case the user doesn't specify type as `ContractLog`
-            log = message.args[0] = ContractLog.model_validate(message.args[0])
-            message.labels["block_number"] = str(log.block_number)
-            message.labels["transaction_hash"] = log.transaction_hash
-            message.labels["log_index"] = str(log.log_index)
+            log = message.args[0]
+            message.labels["txn"] = log.get("transactionHash") or log["transaction_hash"]
+            message.labels["idx"] = log.get("logIndex") or log["log_index"]
 
-        msg = f"{self._create_label(message)} - Started"
+        elif task_type is TaskType.CRON_JOB:
+            message.labels["time"] = str(message.args[0])
+
+        msg = f"{self._create_label(message, task_type)} - Started"
         if message.task_name.startswith("system:"):
             logger.debug(msg)
         else:
@@ -94,6 +67,12 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
         return message
 
     def post_execute(self, message: TaskiqMessage, result: TaskiqResult):
+        if not (task_type_str := message.labels.get("task_type")):
+            # NOTE: Not a Silverback task unless it has this
+            return
+
+        task_type = TaskType(task_type_str)
+
         if self.block_time:
             percentage_time = 100 * (result.execution_time / self.block_time)
             percent_display = f" ({percentage_time:.1f}%)"
@@ -101,7 +80,10 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
         else:
             percent_display = ""
 
-        msg = f"{self._create_label(message)} " f"- {result.execution_time:.3f}s{percent_display}"
+        msg = (
+            f"{self._create_label(message, task_type)} "
+            f"- {result.execution_time:.3f}s{percent_display}"
+        )
         if result.is_err:
             logger.error(msg)
         elif message.task_name.startswith("system:"):

--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -52,8 +52,9 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
 
         elif task_type is TaskType.EVENT_LOG:
             log = message.args[0]
-            message.labels["txn"] = log.get("transactionHash") or log["transaction_hash"]
-            message.labels["idx"] = log.get("logIndex") or log["log_index"]
+            # NOTE: One of these two should exist as keys in `log`
+            message.labels["txn"] = log.get("transactionHash", log.get("transaction_hash"))
+            message.labels["idx"] = log.get("logIndex", log.get("log_index"))
 
         elif task_type is TaskType.CRON_JOB:
             message.labels["time"] = str(message.args[0])

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -375,7 +375,10 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
     async def _block_task(self, task_data: TaskData):
         async def block_handler(ctx: NewHeadsSubscriptionContext):
             self._runtime_task_group.create_task(
-                self.run_task(task_data, clean_hexbytes_dict(ctx.result))
+                self.run_task(
+                    task_data,
+                    clean_hexbytes_dict(ctx.result),  # type: ignore[arg-type]
+                )
             )
 
         sub_id = await self._web3.subscription_manager.subscribe(
@@ -386,7 +389,10 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
     async def _event_task(self, task_data: TaskData):
         async def log_handler(ctx: LogsSubscriptionContext):
             self._runtime_task_group.create_task(
-                self.run_task(task_data, clean_hexbytes_dict(ctx.result))
+                self.run_task(
+                    task_data,
+                    clean_hexbytes_dict(ctx.result),  # type: ignore[arg-type]
+                )
             )
 
         contract_address = task_data.labels.get("address")

--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -10,8 +10,7 @@ import quattro
 from ape import chain
 from ape.logging import logger
 from ape.utils import ManagerAccessMixin
-from ape_ethereum.ecosystem import keccak
-from eth_utils import to_hex
+from eth_utils import to_checksum_address
 from ethpm_types import EventABI
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
@@ -36,7 +35,7 @@ from .main import SilverbackBot, TaskData
 from .recorder import BaseRecorder, TaskResult
 from .state import Datastore, StateSnapshot
 from .types import TaskType, utc_now
-from .utils import async_wrap_iter
+from .utils import async_wrap_iter, clean_hexbytes_dict, decode_topics_from_string
 
 if sys.version_info < (3, 11):
     from exceptiongroup import ExceptionGroup
@@ -108,20 +107,13 @@ class BaseRunner(ABC):
         if self.exceptions > self.max_exceptions or isinstance(result.error, Halt):
             result.raise_for_error()
 
-    async def _checkpoint(
-        self,
-        last_block_seen: int | None = None,
-        last_block_processed: int | None = None,
-    ):
-        """Set latest checkpoint block number"""
+    async def _checkpoint(self):
+        """Fetch latest snapshot from worker"""
         if not self._snapshotting_supported:
             return  # Can't support this feature
 
         elif snapshot := await self.run_system_task(
-            TaskType.SYSTEM_CREATE_SNAPSHOT,
-            last_block_seen,
-            last_block_processed,
-            raise_on_error=False,
+            TaskType.SYSTEM_CREATE_SNAPSHOT, raise_on_error=False
         ):
             await self.datastore.save(snapshot)
 
@@ -148,7 +140,8 @@ class BaseRunner(ABC):
                 if pycron.is_now(cron, dt=current_time):
                     self._runtime_task_group.create_task(self.run_task(task_data, current_time))
 
-            # NOTE: TaskGroup waits for all tasks to complete before continuing
+            # NOTE: Run this every minute (just in case of an unhandled shutdown)
+            self._runtime_task_group.create_task(self._checkpoint())
 
     @abstractmethod
     async def _block_task(self, task_data: TaskData) -> None:
@@ -269,6 +262,8 @@ class BaseRunner(ABC):
 
         NOTE: Must be placed into runtime before called.
         """
+        # Execute one final checkpoint before shutting down
+        await self._checkpoint()
 
         # Execute all shutdown task(s) before shutting down the broker and bot
         try:
@@ -293,10 +288,6 @@ class BaseRunner(ABC):
             ):
                 # NOTE: Just log errors to avoid exception during shutdown
                 logger.error(f"Errors while shutting down:\n{errors_str}")
-
-        # NOTE: Do one last checkpoint to save a snapshot of final state
-        if self._snapshotting_supported:
-            await self._checkpoint()
 
         # NOTE: Will trigger worker shutdown function(s)
         await self.bot.broker.shutdown()
@@ -382,12 +373,10 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
         self.ws_uri = ws_uri
 
     async def _block_task(self, task_data: TaskData):
-
         async def block_handler(ctx: NewHeadsSubscriptionContext):
-            block = self.provider.network.ecosystem.decode_block(dict(ctx.result))
-            await self._checkpoint(last_block_seen=block.number)
-            await self.run_task(task_data, block)
-            await self._checkpoint(last_block_processed=block.number)
+            self._runtime_task_group.create_task(
+                self.run_task(task_data, clean_hexbytes_dict(ctx.result))
+            )
 
         sub_id = await self._web3.subscription_manager.subscribe(
             NewHeadsSubscription(label=task_data.name, handler=block_handler)
@@ -395,33 +384,24 @@ class WebsocketRunner(BaseRunner, ManagerAccessMixin):
         logger.debug(f"Handling blocks via {sub_id}")
 
     async def _event_task(self, task_data: TaskData):
-        if not (contract_address := task_data.labels.get("contract_address")):
-            raise StartupFailure("Contract instance required.")
-
-        if not (event_signature := task_data.labels.get("event_signature")):
-            raise StartupFailure("No Event Signature provided.")
-
-        event_abi = EventABI.from_signature(event_signature)
-
         async def log_handler(ctx: LogsSubscriptionContext):
-            event = next(  # NOTE: `next` is okay since it only has one item
-                self.provider.network.ecosystem.decode_logs([ctx.result], event_abi)
+            self._runtime_task_group.create_task(
+                self.run_task(task_data, clean_hexbytes_dict(ctx.result))
             )
-            # TODO: Fix upstream w/ web3py
-            event.transaction_hash = "0x" + event.transaction_hash.hex()
-            await self._checkpoint(last_block_seen=event.block_number)
-            await self.run_task(task_data, event)
-            await self._checkpoint(last_block_processed=event.block_number)
 
+        contract_address = task_data.labels.get("address")
+        topics = decode_topics_from_string(task_data.labels.get("topics", "")) or None
         sub_id = await self._web3.subscription_manager.subscribe(
             LogsSubscription(
                 label=task_data.name,
-                address=contract_address,
-                topics=[to_hex(keccak(text=event_abi.selector))],
+                address=to_checksum_address(contract_address) if contract_address else None,
+                topics=topics,  # type: ignore[arg-type]
                 handler=log_handler,
             )
         )
-        logger.debug(f"Handling '{contract_address}:{event_abi.name}' logs via {sub_id}")
+        logger.debug(
+            f"Handling '{contract_address or ''}:{topics[0] if topics else ''}' logs via {sub_id}"
+        )
 
     def _daemon_tasks(self) -> list[Coroutine]:
         # NOTE: Handle this as a daemon task (after startup)
@@ -452,51 +432,14 @@ class PollingRunner(BaseRunner, ManagerAccessMixin):
         )
 
     async def _block_task(self, task_data: TaskData):
-        if block_settings := self.bot.poll_settings.get("_blocks_"):
-            new_block_timeout = block_settings.get("new_block_timeout")
-        else:
-            new_block_timeout = None
-
-        new_block_timeout = (
-            new_block_timeout if new_block_timeout is not None else self.bot.new_block_timeout
-        )
-
-        async for block in async_wrap_iter(
-            chain.blocks.poll_blocks(
-                # NOTE: No start block because we should begin polling from head
-                new_block_timeout=new_block_timeout,
-            )
-        ):
-            await self._checkpoint(last_block_seen=block.number)
-            await self.run_task(task_data, block)
-            await self._checkpoint(last_block_processed=block.number)
+        async for block in async_wrap_iter(chain.blocks.poll_blocks()):
+            self._runtime_task_group.create_task(self.run_task(task_data, block))
 
     async def _event_task(self, task_data: TaskData):
-        if not (contract_address := task_data.labels.get("contract_address")):
-            raise StartupFailure("Contract instance required.")
-
-        if not (event_signature := task_data.labels.get("event_signature")):
-            raise StartupFailure("No Event Signature provided.")
-
-        event_abi = EventABI.from_signature(event_signature)
-
-        if address_settings := self.bot.poll_settings.get(contract_address):
-            new_block_timeout = address_settings.get("new_block_timeout")
-        else:
-            new_block_timeout = None
-
-        new_block_timeout = (
-            new_block_timeout if new_block_timeout is not None else self.bot.new_block_timeout
-        )
-
-        async for event in async_wrap_iter(
-            self.provider.poll_logs(
-                # NOTE: No start block because we should begin polling from head
-                address=contract_address,
-                new_block_timeout=new_block_timeout,
-                events=[event_abi],
-            )
+        contract_address = task_data.labels.get("address")
+        event = EventABI.from_signature(task_data.labels["event"])
+        async for log in async_wrap_iter(
+            # NOTE: No start block because we should begin polling from head
+            self.provider.poll_logs(address=contract_address, events=[event])
         ):
-            await self._checkpoint(last_block_seen=event.block_number)
-            await self.run_task(task_data, event)
-            await self._checkpoint(last_block_processed=event.block_number)
+            self._runtime_task_group.create_task(self.run_task(task_data, log))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+import pytest
+
+from silverback.utils import decode_topics_from_string, encode_topics_to_string
+
+
+@pytest.mark.parametrize(
+    "topics",
+    [
+        [],
+        ["0x1"],
+        [None, "0x2"],
+        ["0x1", "0x2"],
+        [["0x1", "0x2"], ["0x1", "0x2"]],
+    ],
+)
+def test_topic_encoding(topics):
+    assert decode_topics_from_string(encode_topics_to_string(topics)) == topics


### PR DESCRIPTION
BREAKING CHANGE(logging): changes the labels of all user tasks
BREAKING CHANGE(platform): runner is not compatible with workers using prev SDK

### What I did

Major refactor of Silverback's task management system so that it can take advantage of multiprocess workers to reduce latency significantly (in some cases a 20x improvement!)

fixes: #81

### How I did it

1. Moved block/log decoding into the worker side (e.g. `runner.py` -> `main.py`)
2. Put tasks into runner's TaskGroup that exists during runtime

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
