### PR TITLE
chore(CI): revert build action back to v1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build Examples
-        uses: SilverbackLtd/build-action@v1.2
+        uses: SilverbackLtd/build-action@v1
         with:
             push: ${{ github.event_name != 'pull_request' }}
             tag: latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -128,7 +128,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build Examples
-        uses: SilverbackLtd/build-action@main
+        uses: SilverbackLtd/build-action@v1.2
         with:
             push: ${{ github.event_name != 'pull_request' }}
             tag: latest


### PR DESCRIPTION
### What I did

Temporarily needed it on a custom tag just to avoid build failure

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
