### PR TITLE
refactor(Results): add default in-memory result backend

### DIFF
--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings, ManagerAccessMixin):
 
     ENABLE_METRICS: bool = False
 
-    RESULT_BACKEND_CLASS: str = ""
+    RESULT_BACKEND_CLASS: str = "taskiq.brokers:InmemoryResultBackend"
     RESULT_BACKEND_URI: str = ""  # To be deprecated in 0.6
     RESULT_BACKEND_KWARGS: dict[str, Any] = dict()
 

--- a/silverback/settings.py
+++ b/silverback/settings.py
@@ -38,7 +38,7 @@ class Settings(BaseSettings, ManagerAccessMixin):
 
     ENABLE_METRICS: bool = False
 
-    RESULT_BACKEND_CLASS: str = "taskiq.brokers:InmemoryResultBackend"
+    RESULT_BACKEND_CLASS: str = "taskiq.brokers.inmemory_broker:InmemoryResultBackend"
     RESULT_BACKEND_URI: str = ""  # To be deprecated in 0.6
     RESULT_BACKEND_KWARGS: dict[str, Any] = dict()
 


### PR DESCRIPTION
### What I did

Wanted to add out-of-the-box support to the runner for results, but realized it didn't have the in-memory backend to store them by default

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
