### PR TITLE
feat(Runner): hide tasks that are configured from an SDK

### DIFF
--- a/silverback/middlewares.py
+++ b/silverback/middlewares.py
@@ -60,7 +60,7 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
             message.labels["time"] = str(message.args[0])
 
         msg = f"{self._create_label(message, task_type)} - Started"
-        if message.task_name.startswith("system:"):
+        if ":" in message.task_name:
             logger.debug(msg)
         else:
             logger.info(msg)
@@ -87,7 +87,7 @@ class SilverbackMiddleware(TaskiqMiddleware, ManagerAccessMixin):
         )
         if result.is_err:
             logger.error(msg)
-        elif message.task_name.startswith("system:"):
+        elif ":" in message.task_name:
             logger.debug(msg)
         else:
             logger.success(msg)


### PR DESCRIPTION
### What I did

Been experimenting with adding new tasks internally to an SDK, and I want to do it in a way where user tasks aren't getting crowded out

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
