### PR TITLE
fix(Runner): don't raise `NoTasksAvailableError` if a cron tasks exists

### DIFF
--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -255,7 +255,12 @@ class BaseRunner(ABC):
             TaskType.SYSTEM_USER_TASKDATA, TaskType.EVENT_LOG
         )
 
-        if len(new_block_tasks_taskdata) == len(event_log_tasks_taskdata) == 0:
+        if (
+            len(cron_tasks_taskdata)
+            == len(new_block_tasks_taskdata)
+            == len(event_log_tasks_taskdata)
+            == 0
+        ):
             raise NoTasksAvailableError()
 
         return [


### PR DESCRIPTION
### What I did

Don't raise the `NoTasksAvailableError` exception on startup if there is at least 1 cron task

fixes: #243

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
