### PR TITLE
refactor(Cluster): support Ory auth system

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN pip wheel . --wheel-dir=/wheels --no-deps
 # Install from wheels
 FROM ghcr.io/apeworx/ape:${BASE_APE_IMAGE_TAG:-latest}
 USER root
+RUN apt-get update && apt-get install -y wget git  # for temporary fork install
 COPY --from=builder /wheels/*.whl /wheels
 RUN pip install --upgrade pip \
     && pip install \

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "quattro>=25.2,<26",  # Manage task groups and background tasks
         "taskiq[metrics]>=0.11.16,<0.12",
         "tomlkit>=0.12,<1",  # For reading/writing global platform profile
-        "fief_client @ git+https://github.com/ApeWorX/fief-python@fix/support-ory#egg=fief_client[cli]",  # for platform auth/cluster login
+        "fief_client @ git+https://github.com/ApeWorX/fief-python@fix/support-ory#egg=fief_client[cli]",  # for platform auth/cluster login  # noqa: E501
         "yaspin",  # NOTE: Required by fief-client
         "web3>=7.7,<8",  # TODO: Remove when Ape v0.9 is released (Ape v0.8 allows web3 v6)
     ],

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "quattro>=25.2,<26",  # Manage task groups and background tasks
         "taskiq[metrics]>=0.11.16,<0.12",
         "tomlkit>=0.12,<1",  # For reading/writing global platform profile
-        "fief-client[cli]>=0.19,<1",  # for platform auth/cluster login
+        "git+https://github.com/ApeWorX/fief-python@fix/support-ory#egg=fief_client[cli]",  # for platform auth/cluster login
         "web3>=7.7,<8",  # TODO: Remove when Ape v0.9 is released (Ape v0.8 allows web3 v6)
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
         "quattro>=25.2,<26",  # Manage task groups and background tasks
         "taskiq[metrics]>=0.11.16,<0.12",
         "tomlkit>=0.12,<1",  # For reading/writing global platform profile
-        "git+https://github.com/ApeWorX/fief-python@fix/support-ory#egg=fief_client[cli]",  # for platform auth/cluster login
+        "fief_client @ git+https://github.com/ApeWorX/fief-python@fix/support-ory#egg=fief_client[cli]",  # for platform auth/cluster login
         "web3>=7.7,<8",  # TODO: Remove when Ape v0.9 is released (Ape v0.8 allows web3 v6)
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
         "taskiq[metrics]>=0.11.16,<0.12",
         "tomlkit>=0.12,<1",  # For reading/writing global platform profile
         "fief_client @ git+https://github.com/ApeWorX/fief-python@fix/support-ory#egg=fief_client[cli]",  # for platform auth/cluster login
+        "yaspin",  # NOTE: Required by fief-client
         "web3>=7.7,<8",  # TODO: Remove when Ape v0.9 is released (Ape v0.8 allows web3 v6)
     ],
     entry_points={

--- a/silverback/_click_ext.py
+++ b/silverback/_click_ext.py
@@ -255,7 +255,15 @@ def platform_client(show_login: bool = True):
 
             if show_login:
                 user_id = userinfo["sub"]
-                username = userinfo["fields"].get("username")
+                # TODO: Refactor once migration is completed
+                username = (
+                    # Ory (new)
+                    userinfo.get("preferred_username")
+                    # Fief (current)
+                    or userinfo.get("fields", {}).get("username")
+                    # Fallback (for both)
+                    or userinfo["sub"]
+                )
                 click.echo(
                     f"{click.style('INFO', fg='blue')}: "
                     f"Logged in to '{click.style(profile.host, bold=True)}' as "


### PR DESCRIPTION
### What I did

Added support for Ory auth system (which happens to work decently well w/ `fief-client` already muhaha)

BREAKING CHANGE: users will have to delete or migrate their `~/.silverback/` folder contents since the the auth tokens are stored there (as well as the auth profile needs to be updated)

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)