### PR TITLE
fix(CLI): wrong path for contracts folder

### DIFF
--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -45,7 +45,7 @@ def dockerfile_template(
         dockerfile.append("RUN ape plugins install -U .")
 
     if contracts_folder:
-        dockerfile.append(f"COPY {contracts_folder} /app")
+        dockerfile.append(f"COPY {contracts_folder} /app/{contracts_folder}")
         dockerfile.append("RUN ape compile")
 
     bot_src = f"{bot_path.parent}/{bot_path.name}" if include_bot_dir else bot_path.name


### PR DESCRIPTION
### What I did

Noticed that when including sources, this does not put the contracts into the right location in the image

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
