### PR TITLE
fix(CLI): display module errors better

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ def test_run_no_bots(cli, runner):
         "Usage: cli run [OPTIONS] [BOT]\n"
         "Try 'cli run --help' for help.\n\n"
         "Error: Invalid value for '[BOT]': "
-        "Nothing to run: No bot argument(s) given and no bots module found.\n"
+        "Bot module 'bot:bot' not found.\n"
     )
     assert result.output == expected
 


### PR DESCRIPTION
### What I did

Noticed that sometimes there was issues loading a bot when there was other modules in the bot that were not installed properly. Those issues presented under the same error that showed when the bot module itself did not exist. Separated out some of these error conditions, and also added a few more to help users understand how to properly use the `[BOT]` parameter in `silverback run` and `silverback worker` commands, in order to reduce confusion in the CLI.

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
