### PR TITLE
fix: handle ContractEventWrapper containers better

### DIFF
--- a/silverback/main.py
+++ b/silverback/main.py
@@ -448,7 +448,8 @@ class SilverbackBot(ManagerAccessMixin):
                     )
 
             else:  # Just pick the last event, all are duplicates anyways
-                # NOTE: More likely to pick generic package-based `.at` types e.g. `ape_tokens.ERC20`
+                # NOTE: More likely to pick generic `ContractContainer.at` instances
+                #       (e.g. `Token.at` from `ape_tokens`)
                 container = container.events[-1]
 
         # Register user function as task handler with our broker


### PR DESCRIPTION
### What I did

Had a really annoying time doing stuff that used `ape-tokens` plugin, as the token instance will typically deviate from what comes bundled with the plugin

This gets around that by trying to find which event in the wrapper matches filtered args that you specify. Also updates the default to whatever the last one is as that is typically what is "merged" in the contract type on subsequent loads (after the first)

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
