### PR TITLE
fix(Runner): incorrect handling for metrics `value:<op>` label

### DIFF
--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -172,7 +172,7 @@ class BaseRunner(ABC):
         value_thresholds = {
             op: Decimal(val)  # NOTE: Decimal is most flexible at handling strings
             for lbl, val in task_data.labels.items()
-            if lbl.startswith("value:") and (op := getattr(operator, lbl.lstrip("value:"), None))
+            if lbl.startswith("value:") and (op := getattr(operator, lbl[6:]))
         }
 
         def exceeds_value_threshold(data: ScalarType) -> bool:


### PR DESCRIPTION
### What I did

Noticed that there was bad data sanitation of the `value:<op>` label for `.on_metric` tasks, causing them to always trigger even when the conditions were not true.

fixes: #276

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
