### PR TITLE
docs(Userguides): refactor all userguides for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
-# Quick Start
+# Overview
 
-Silverback lets you create and deploy your own Python bots that respond to on-chain events.
-The Silverback library leverages the [Ape](https://docs.apeworx.io/ape/stable/userguides/quickstart) development framework as well as it's ecosystem of plugins and packages to enable you to develop simple-yet-sophisticated automated bots that can listen and respond to live chain data.
+Silverback lets you create your own Python bots that respond in real-time to blockchain events.
+The Silverback library leverages the [Ape](https://docs.apeworx.io/ape/stable/userguides/quickstart)
+development framework, as well as it's ecosystem of plugins and packages, to let you to develop
+capable automated bots that trigger your own custom Python logic whenever a specific event occurs.
 
-Silverback bots are excellent for use cases that involve continuously monitoring and responding to on-chain events, such as newly confirmed blocks or contract event logs.
+Silverback bots are excellent for use cases that require continuous monitoring for specific conditions,
+and then require a direct response such as sending a notification or submitting a transaction.
 
 Some examples of these types of bots:
 
-- Monitoring new pool creations, and depositing liquidity
-- Measuring trading activity of popular pools
-- Listening for large swaps to update a telegram group
-
-## Documentation
-
-Please read the [development userguide](https://docs.apeworx.io/silverback/stable/userguides/development.html) for more information on how to develop a bot.
+- Index raw events from a protocol, and derive bespoke metrics in real-time
+- Monitor new pool creations, and deposit liquidity if conditions are favorable
+- Measure trading activity of a pool, and use those metrics to inform your own trading algorithm
+- Listen for large swaps by whales, in order to update a Telegram group or Discord channel
+- Perform protocol actions such as liquidations or oracle updates
 
 ## Dependencies
 
@@ -21,112 +22,80 @@ Please read the [development userguide](https://docs.apeworx.io/silverback/stabl
 
 ## Installation
 
-Silverback relies heavily on the Ape development framework, so it's worth it to familarize yourself with how to install Ape and it's plugins using the [Ape installation userguide](https://docs.apeworx.io/ape/latest/userguides/quickstart#installation).
+Silverback relies heavily on the Ape development framework, so it's worth it to familarize yourself
+with how to install Ape and any necessary plugins using the
+[Ape installation userguide](https://docs.apeworx.io/ape/stable/userguides/quickstart#installation).
 
 ```{note}
-It is suggested that you use a virtual environment of your choosing, and then install the Silverback package via one of the following options.
+It is suggested that you use a virtual environment of your choosing,
+and then install the Silverback package via one of the following options.
 ```
 
 ### via `pip`
 
-You can install the latest release via [`pip`](https://pypi.org/project/pip/):
+You can install the latest release via [`pip`](https://pypi.org/project/pip):
 
 ```bash
 pip install silverback
 ```
 
-### via `setuptools`
+### via `uv`
 
-You can clone the repository and use [`setuptools`](https://github.com/pypa/setuptools) for the most up-to-date version:
+You can install the latest release via [`uv`](https://docs.astral.sh/uv/getting-started/installation)
 
 ```bash
-git clone https://github.com/ApeWorX/silverback.git silverback
-cd silverback
-python3 setup.py install
+uv tool install silverback
+```
+
+```{note}
+To install 2nd/3rd party Ape plugins using `uv tool`, you will need to add
+`--with ape-<plugin name>` to ensure the environment has them.
 ```
 
 ## Quick Usage
 
-Checkout [the example](https://github.com/ApeWorX/silverback/blob/main/bots/example.py) to see how to use the library.
+View [the example](https://github.com/ApeWorX/silverback/blob/main/bots/example.py)
+to see how to use the library to build a bot.
+The example shows off a variety of Silverback's features and functionality,
+and you can learn more about this in the [development guide](https://docs.apeworx.io/silverback/stable/userguides/development).
+
+### Running Locally
+
+Download the example to `bots/example.py`.
 
 ```{note}
 The example makes use of the [Ape Tokens](https://github.com/ApeWorX/ape-tokens) plugin.
 Be sure to properly configure your environment for the USDC and YFI tokens on Ethereum mainnet.
 ```
 
-To run your bot against a live network, this SDK includes a simple bot command you can use via:
+To run this bot against a live network, this SDK includes a simple command you can use as follows:
 
 ```sh
-$ silverback run example --network :mainnet:alchemy
+silverback run example --network :mainnet:alchemy
 ```
 
-```{note}
-This bot uses an in-memory task broker by default.
-If you want to learn more about what that means, please visit the [development userguide](https://docs.apeworx.io/silverback/stable/userguides/development.html).
-```
+### Running from a Container
 
-```{note}
-It is suggested that you create a bots/ folder in the root of your project.
-Silverback will automatically register files in this folder as separate bots that can be run via the `silverback run` command.
-```
-
-```{note}
-It is also suggested that you treat this as a scripts folder, and do not include an __init__.py
-If you have a complicated project, follow the previous example to ensure you run the bot correctly.
-```
-
-```{note}
-A final suggestion would be to name your `SilverbackBot` object `bot`. Silverback automatically searches 
-for this object name when running. If you do not do so, once again, ensure you replace `example` with 
-`example:<name-of-object>` the previous example.
-```
-
-To auto-generate Dockerfiles for your bots, from the root of your project, you can run:
-
-```bash
-silverback build --generate
-```
-
-This will place the generated dockerfiles in a special directory in the root of your project.
-
-As an example, if you have a bots directory that looks like:
-
-```
-bots/
-├── botA.py
-├── botB.py
-├── botC.py
-```
-
-This method will generate 3 Dockerfiles:
-
-```
-.silverback-images/
-├── Dockerfile.botA
-├── Dockerfile.botB
-├── Dockerfile.botC
-```
-
-These Dockerfiles can be deployed with the `docker push` command documented in the next section so you can use it in cloud-based deployments.
-
-```{note}
-As an aside, if your bots/ directory is a python package, you will cause conflicts with the dockerfile generation feature. This method will warn you that you are generating bots for a python package, but will not stop you from doing so. If you choose to generate dockerfiles, the user should be aware that it will only copy each individual file into the Dockerfile, and will not include any supporting python functionality. Each python file is expected to run independently. If you require more complex bots, you will have to build a custom docker image.
-```
-
-## Docker Usage
+Silverback makes it really easy to containerize your bots in order to run them inside of a container orchestrator.
+This makes running our example even easier, all you need is `docker` (or `podman`) installed and then you can run via:
 
 ```sh
-$ docker run -it apeworx/silverback-example:latest run --network :mainnet
+$ docker run -it ghcr.io/apeworx/silverback-example:latest -- run --network :mainnet
 ```
 
 ```{note}
-The Docker image we publish uses Python 3.11.
+The base silverback image we publish uses Python 3.11 for it's runtime.
+Make sure all your packages are installable using this version.
 ```
+
+For convienence, we offer the [Silverback Platform](https://silverback.apeworx.io),
+which is a hosted service that allows you to run many of your bots concurrently on different blockchain networks.
 
 ## Development
 
-This project is under active development in preparation of the release of the [Silverback Platform](https://silverback.apeworx.io).
-Things might not be in their final state and breaking changes may occur.
+This project is under active development to match the capabilities of the
+[Silverback Platform](https://silverback.apeworx.io).
+Things might not be in their final state and breaking changes may occur in minor revisions.
 Comments, questions, criticisms and pull requests are welcomed.
 
-See [Contributing](https://github.com/ApeWorX/silverback/blob/main/CONTRIBUTING.md) for more information.
+See [Contributing](https://github.com/ApeWorX/silverback?tab=contributing-ov-file) for more information.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,9 @@
     :userguides:
         - quickstart
         - development
-        - managing
         - deploying
+        - managing
+        - advanced
     :commands:
         - run
         - cluster

--- a/docs/userguides/advanced.md
+++ b/docs/userguides/advanced.md
@@ -1,0 +1,299 @@
+# Advanced Topics
+
+There are a number of "advanced topics" that you might want to understand before using Silverback,
+especially for production use. The following topics are shared not in any particular order.
+
+## Handling Reorgs
+
+For some chains, there is a risk of a "reorg", or block reorganization, that may impact Silverback's
+handler functions as function calls could be triggered repeatedly with the same arguments provided.
+Block reorganizations are an inherent risk to your bot's design, and should be handled accordingly.
+
+```{important}
+Reorg handling in subscription methods is not a completely specified in the Ethereum RPC specification
+(see [execution specs](https://github.com/ethereum/execution-apis/issues/496)),
+and may be handled in different fashions based on the chain's consensus technique and client parameterization.
+```
+
+### Block Reorgs
+
+When a chain experiences a reorg, typically what will occur is that block subscriptions will "walk
+backwards" to find the last valid block emitted to subscribers from the canonical chain, and then
+re-emit new blocks starting from the last block shared in common (but with different content).
+In order to properly handle reorgs, you should make sure that important uses of block data are
+_indexed by number_, and overwrite the recorded data at those indexes with the newer data.
+
+As a concrete example, we have an application that tracks a parameter `last_hash` in `bot.state`.
+We don't really have a problem yet because while we do get the "rolled back" blocks as a part of
+the new canonical chain, we are only interested in what the value of the last block is:
+
+```py
+@bot.on_(chain.blocks)
+def update_last_hash(blk):
+    bot.state.last_hash = blk.hash
+```
+
+Here is a call sequence of how this function might get called in a reorg scenario:
+
+```py
+update_last_hash(blk1) # .hash: abc
+update_last_hash(blk2) # .hash: def
+update_last_hash(blk3) # .hash: ghi
+# Reorg happens! `blk2` (.hash: def) and onwards has changed
+update_last_hash(blk2) # .hash: jkl, replaced .hash: def
+update_last_hash(blk3) # .hash: mno, replaced .hash: ghi
+```
+
+Our handling is safe because we just want whatever the last valid block's hash was.
+_However_, we have to be careful how we use this identifier,
+because that value now needs to be considered tainted for downstream use.
+Let's say for example we are dumping this data into a database for the purpose of tracking blocks,
+and we decide to use the block's hash as our primary key to track them:
+
+```py
+@bot.on_(chain.blocks)
+def update_db(blk):
+    bot.state.db["blocks"][blk.hash] = blk
+```
+
+The records in our database still won't have conflicts (as the primary key is content-addressing the whole block),
+_but_ we likely have a problem now because there are **2 different blocks** having the same value for field `.number`!
+This is likely to cause issues downstream when using our database and trying to fetch a sequence of blocks ordered by number.
+So instead, we actually want to use the `.number` field as the primary key so that when we update the record at that key,
+we are actually _replacing_ the old block with the new one (and we will always have a single, canonical history):
+
+```py
+@bot.on_(chain.blocks)
+def update_db(blk):
+    bot.state.db["blocks"][blk.number] = blk
+```
+
+A very simple change that now handles rollbacks occuring!
+
+```{note}
+Please see [the Geth documentation](https://geth.ethereum.org/docs/interacting-with-geth/rpc/pubsub#newheads)
+for more information on how block reorgs work.
+```
+
+### Event Log Reorgs
+
+There is a similar issue when using contract event log subscriptions,
+but the issue can be resolved in a more straightforward way.
+As of [Ape v0.8.43](https://github.com/ApeWorX/ape/pull/2727),
+our event log model now includes the `.removed` field,
+which is set to `True` if the log is no longer included in the canonical chain.
+It will then "re-issue" the same log if the transaction it originated from replays on the new set of blocks.
+
+Let's use the same database analogy again.
+This time, we are storing account balances for ERC20 token transfers in our database (indexed by account).
+Our naive implementation of this might look like:
+
+```py
+@bot.on_(ERC20.Transfer)
+def track_balances(log):
+    bot.state.db["balances"][log.receiver] += log.amount
+    bot.state.db["balances"][log.sender] -= log.amount
+```
+
+However when a re-org occurs, we are actually going to get the same log a second time but with the `.removed` field set,
+indicating the operation has been "reversed".
+Without handling this we will "double count" the event and have the wrong answer
+(the balances mismatches the on-chain `.balanceOf` call).
+We can easily handle this with just a little bit of logic added to "reverse" the operation in our off-chain index:
+
+```py
+@bot.on_(ERC20.Transfer)
+def track_balances(log):
+    if log.removed:  # NOTE: Undo balance update
+        bot.state.db["balances"][log.receiver] -= log.amount
+        bot.state.db["balances"][log.sender] += log.amount
+    else:
+        bot.state.db["balances"][log.receiver] += log.amount
+        bot.state.db["balances"][log.sender] -= log.amount
+```
+
+Now we are fully handling the logical implications of an event log reorg!
+
+```{note}
+Please see [the Geth documentation](https://geth.ethereum.org/docs/interacting-with-geth/rpc/pubsub#logs)
+for more information about how event log reorgs work
+```
+
+## Worker Events
+
+If you have heavier resources you want to load during startup,
+or want to initialize things per-worker like database connections,
+you can add a _worker startup function_ like so:
+
+```python
+@bot.on_worker_startup()
+def handle_on_worker_startup(state):
+    # Connect to DB, set initial state, etc
+    ...
+
+@bot.on_worker_shutdown()
+def handle_on_worker_shutdown(state):
+    # cleanup resources, close connections cleanly, etc
+    ...
+```
+
+This function takes a parameter `state` that you can use for storing the results
+of your startup computation or resources that you have provisioned.
+**This is different from `bot.state`**, and will make it accessible via `taskiq.Context` dependency injection in other tasks.
+
+```{important}
+This is not a Silverback native feature, but rather a feature available from the TaskIQ library that Silverback uses.
+
+See the [Taskiq Documentation](https://taskiq-python.github.io/guide/state-and-deps.html) to learn more about it.
+```
+
+This feature is useful for ensuring that your workers (specifically when using [Distributed Execution](#distributed-execution))
+have the resources necessary to properly handle any updates you want to make in your handler functions,
+such as connecting to the Telegram API, an SQL or NoSQL database connection, or something else.
+
+Giving each worker it's own connection to a database or API could **dramatically speed up** the use of contested resources:
+
+```py
+@bot.on_worker_startup()
+async def connect_db(state):
+    state.db = await Connection("posgres://localhost").__aenter__()
+
+
+@bot.on_(Token.Transfer)
+async def store_token(log, context: Annotated[Context, TaskiqDepends()]):
+    token = await context.state.db.get(log.contract_address)
+    token.balances[log.sender] -= log.amount
+    token.balances[log.receiver] += log.amount
+    await context.state.db.add(token)
+    await context.state.db.commit()
+
+
+@bot.on_worker_shutdown()
+async def handle_on_worker_shutdown(state):
+    await state.db.__aexit__()
+
+```
+
+```{important}
+The worker startup/shutdown functions will run on **every worker process** (N times for N workers).
+```
+
+## Distributed Execution
+
+Using only the `silverback run ...` command in the default configuration executes everything in one process,
+and the job queue is ke-pt completely in-memory with a shared state.
+This is very useful for local testing purposes, but in some high-volume environments,
+you may want to deploy your Silverback bot in a "distributed configuration",
+using multiple processes to handle the messages in parallel in order to acheive a higher throughput rate.
+
+Operating in this mode, there are two components: the client and the workers.
+The client handles triggering Silverback events (listening for blocks and contract event logs)
+and then creates jobs for the workers to process in an asynchronous manner using a "broker".
+
+For this to work, you must configure a [TaskIQ broker](https://taskiq-python.github.io/guide/architecture-overview.html#broker)
+capable of distributed processing, such as ZeroMQ or Redis.
+Additonally, it is highly suggested you should also configure a
+[TaskIQ result backend](https://taskiq-python.github.io/guide/architecture-overview.html#result-backend)
+in order to process and store the results of executing tasks,
+otherwise you will not collect Metrics or be able to execute any Metric Callbacks.
+
+```{note}
+Without configuring a result backend,
+Silverback may not work as expected since all your tasks will now suddenly return `None` instead of the actual result.
+```
+
+For instance, with [`taskiq_redis`](https://github.com/taskiq-python/taskiq-redis) you could do something like this to configure silverback:
+
+```bash
+pip install taskiq-redis
+export SILVERBACK_BROKER_CLASS="taskiq_redis:ListQueueBroker"
+export SILVERBACK_BROKER_KWARGS='{"queue_name": "taskiq", "url": "redis://127.0.0.1:6379"}'
+export SILVERBACK_RESULT_BACKEND_CLASS="taskiq_redis:RedisAsyncResultBackend"
+export SILVERBACK_RESULT_BACKEND_URI="redis://127.0.0.1:6379"
+```
+
+Then you should start the worker process with 2 worker subprocesses:
+
+```bash
+silverback worker -w 2 --network :mainnet
+```
+
+Finally, run the client via:
+
+```bash
+silverback run --network :mainnet
+```
+
+```{important}
+Run the client **after** running the workers, otherwise there will be a delay in startup.
+```
+
+After the startup sequence, the client will submit tasks on triggers to the 2 worker subprocesses,
+and all task queue and results data will be go through Redis back to the client once the workers complete them.
+
+## Running Containers with Local Keyfiles
+
+While not a recommended best practice, it is possible to "attach" your keyfiles and use them inside of a containerized bot.
+You can do this using the "volumes" feature of [`docker`](https://docs.docker.com/engine/storage/volumes/)
+or [`podman`](https://docs.podman.io/en/latest/markdown/podman-volume.1.html).
+
+The basic idea is to add your local `~/.ape/accounts` folder into your container's runtime environment,
+and then use the [Ape automation documentation](https://docs.apeworx.io/ape/stable/userguides/accounts#automation)
+to set up non-interactive decryption of the relevant account using the corresponding alias you have supplied via `--account`.
+
+A full example would look like the following:
+
+```sh
+docker run \
+    --volume ~/.ape/accounts:/home/harambe/.ape/accounts \
+    --env APE_ACCOUNTS_<alias>_PASSPHRASE=... \
+    ghcr.io/image/name -- run --network ... --account <alias>
+```
+
+```{warning}
+This is not a recommended best practice, and relies on understanding the volume feature of your runtime tool.
+
+By sharing your filesystem with the docker container, you could allow a container to **read your keyfiles**
+shared from your local environemnt and allow decrypting them.
+
+Running a container image that **is not your own** could have drastic impacts on any of these connected wallets,
+including **total loss of funds**.
+Use this technique only if you trust the source of the container image.
+```
+
+## Cluster Access
+
+Sometimes, there are scenarios where you want to create a bot that has the capability to control other bots.
+This might make sense if you have one type of bot that monitors a particular contract instance to interact with it,
+and then another type of bot that monitors the Factory contract which can produce more instances.
+Another example is if you want a bot that can monitor the performance of other bots in your cluster,
+and then be able to stop any one of them if it discovers any issues while monitoring it.
+
+```py
+@bot.on_(factory.NewPool)
+async def new_arb_bot(log):
+    vg = bot.cluster.new_variable_group(
+        name=f"{log.token0}-{log.token1}-pool",
+        variables={"POOL": log.pool_address},
+    )
+    bot = bot.cluster.new_bot(
+        name=f"{log.token0}-{log.token1}-arb",
+        ...,
+        environment=[vg.name, ...],
+    )
+```
+
+Creating this type of setup allows a sort of "agentic scaling" where you can quickly scale up your bot cluster's
+on-chain "footprint" and cover more ground by having multiple other bots handling situations you encounter.
+This also can more effectively distribute the cluster load when you have large quantities of events to be handled,
+and need to dynamically scale in order to add more capacity in response to on-chain conditions.
+
+```{important}
+Testing cluster access is not practical without deploying on the [Silverback Platform](./platform.html).
+The cluster implements additional authorization checks based on the `--cluster-access` flag provided
+with the [`silverback cluster bots new`](../commands/cluster#silverback-cluster-bots-new)
+and [`silverback cluster bots update`](../commands/cluster#silverback-cluster-bots-update) commands.
+```
+
+_Added in Silverback SDK [v0.7.35](https://github.com/ApeWorX/silverback/releases/tag/v0.7.35)_
+_Support added in Silverback Cluster [v0.7.0](https://silverback.apeworx.io/changelog#cluster-v0-7-0)_

--- a/docs/userguides/deploying.md
+++ b/docs/userguides/deploying.md
@@ -1,36 +1,40 @@
 # Deploying Bots
 
-In this guide, we are going to show you more details on how to deploy your bot to the [Silverback Platform](https://silverback.apeworx.io).
+In this guide, we are going to show you more details on how to build and deploy your bots
+to a production hosting environment, like the [Silverback Platform](https://silverback.apeworx.io).
 
-```{note}
-You will need to have created a cluster in your workspace first. More information can be found in the [Managing Your Platform](./managing.md).
+```{important}
+You need a containerization tool to get started, like [Docker](https://docs.docker.com)
+or [Podman](https://podman-desktop.io) (ships on some Linux distros).
 ```
 
-In order to deploy your bots to the Cluster, we will first have to containerize our Bots and upload them to a container registry that our Cluster can access.
-
 ```{note}
-Building a container for your bot can be an advanced topic, we have included the `silverback build` subcommand to help assist in generating Dockerfiles.
+If both tools are installed, Silverback prefers using Podman over Docker.
+Podman is daemonless and allows rootless container execution, enhancing system security.
 ```
 
 ## Building your Bot
 
-To build your container definition(s) for your bot(s), you can use the [`silverback build`][silverback-build] command. This command searches your `bots` directory for python modules, then auto-generates Dockerfiles.
+In order to deploy your bot to a "production" orchestration solution,
+we will first have to containerize them and then publish to a container registry.
+Building a container for your bot can be an advanced topic,
+so we have included the [`silverback build`][silverback-build] subcommand to help assist in generating successful builds.
 
-For example, if your directory is structured as suggested in [development](./development), and your `bots/` directory looks like this:
+To auto-generate Dockerfiles for your bots before building them, from the root of your project you can run:
+
+```bash
+silverback build --generate
+```
+
+This will generate container build files in a special directory in the root of your project.
+
+As an example, if you have a bots directory that looks like:
 
 ```
 bots/
 ├── botA.py
 ├── botB.py
-├── botC.py
-```
-
-Then you can use `silverback build --generate` to generate 3 separate Dockerfiles for those bots, and start trying to build them.
-
-Those Dockerfiles will appear under `.silverback-images/` as follows:
-
-```bash
-silverback build --generate
+└── botC.py
 ```
 
 This method will generate 3 Dockerfiles:
@@ -39,168 +43,50 @@ This method will generate 3 Dockerfiles:
 .silverback-images/
 ├── Dockerfile.botA
 ├── Dockerfile.botB
-├── Dockerfile.botC
+└── Dockerfile.botC
 ```
 
-You can retry you builds using the following (assuming you don't modify the structure of your project):
+It will then automatically build them for you (monitor the output for any issues).
+Assuming the build commands succeed, you will have fully-built images that you can push into a Registry.
+
+```{note}
+If you chose the `bot/` project structure and `bot` is a Python package, you will be unable to use the dockerfile generation feature.
+This method will warn you that you are generating bots for a python package, but will not stop you from attempting to do so.
+When you generate the dockerfiles, be aware that it will only copy the `bot/` folder into the Dockerfile,
+and will not include any supporting python functionality.
+Each python module is expected to run independently.
+If you require more complex bots, you should use custom dockerfiles.
+```
+
+You can also re-build your images now using the following (assuming you don't modify the structure of your project):
 
 ```bash
 silverback build
 ```
 
-You can then push your image to your registry using:
+This can be useful if you make small logic changes to your bot.
+
+## Publishing your Bot
+
+Use the `docker push` (or `podman push`) command to push to a Registry so you can use it in cloud-based deployments.
 
 ```bash
 docker push your-registry-url/project/botA:latest
 ```
 
-TODO: The ApeWorX team has github actions definitions for building, pushing and deploying.
+### Using the Github Action
 
-If you are unfamiliar with docker and container registries, you can use the \[[github-action]\].
+The ApeWorX team has created a [Github Action](https://github.com/SilverbackLtd/build-action)
+for building and publishing your bot images in a bot project repository repo using Github Actions CI.
 
-You do not need to build using this command if you use the github action, but it is there to help you if you are having problems figuring out how to build and run your bot images on the cluster successfully.
+If you are unfamiliar with docker and container registries, you should use the Action.
 
-TODO: Add how to debug containers using `silverback run` w/ `taskiq-redis` broker
+You do not need to build locally using `silverback build` if you use the Github Action to publish,
+but it is there to help you if you are having problems figuring out how to build in CI,
+or if your bot images will not run in production successfully.
 
-## Adding Environment Variables
+You can also debug containers in an environment similar to the Silverback Platform using
+[Distributed Execution][distributed-execution] Mode.
 
-Once you have created your bot container image, you might know of some environment variables the image requires to run properly.
-Thanks to it's flexible plugin system, ape plugins may also require specific environment variables to load as well.
-Silverback Clusters include an environment variable management system for exactly this purpose,
-which you can manage using [`silverback cluster vars`][silverback-cluster-vars] subcommand.
-
-The environment variable management system makes use of a concept called "Variable Groups" which are distinct collections of environment variables meant to be used together.
-These variable groups will help in managing the runtime environment of your Bots by allowing you to segregate different variables depending on each bot's needs.
-
-To create an environment group, use the [`silverback cluster vars new`][silverback-cluster-vars-new] command and give it a name and a set of related variables.
-For instance, it may make sense to make a group of variables for your favorite Ape plugins or services, such as RPC Providers, Blockchain Data Indexers, Etherscan, etc.
-You might have a database connection that you want all your bots to access.
-
-```{warning}
-All environment variables in Silverback Clusters are private, meaning they cannot be viewed after they are uploaded.
-However, your Bots will have full access to their values from within their runtime environment, so be careful that you fully understand what you are sharing with your bots.
-
-Also, understand your build dependencies within your container and make sure you are not using any vulnerable or malicious packages.
-
-**NEVER** upload your private key in a plaintext format!
-
-Use _Ape Account Plugins_ such as [`ape-aws`](https://github.com/ApeWorX/ape-aws) to safely manage access to your hosted keys.
-```
-
-```{note}
-The Etherscan plugin _will not function_ without an API key in the cloud environment.
-This will likely create errors running your bots if you use Ape's `Contract` class.
-```
-
-To list your Variable Groups, use [`silverback cluster vars list`][silverback-cluster-vars-list].
-To see information about a specific Variable Group, including the Environment Variables it includes, use [`silverback cluster vars info`][silverback-cluster-vars-info]
-To remove a variable group, use [`silverback cluster vars remove`][silverback-cluster-vars-remove],
-
-```{note}
-You can only remove a Variable Group if it is not referenced by any existing Bot.
-```
-
-Once you have created all the Variable Group(s) that you need to operate your Bot, you can reference these groups by name when adding your Bot to the cluster.
-
-## Private Container Registries
-
-If you are using a private container registry to store your images, you will need to provide your bot with the necessary credentials to access it.
-First you will need to add your credentials to the cluster with the [`silverback cluster registry new`][silverback-cluster-registry-new] command.
-
-Then you can provide the name of these credentials when creating your bot with the [`silverback cluster bots new`][silverback-cluster-bots-new] or [`silverback cluster bots update`][silverback-cluster-bots-update] commands.
-
-## Deploying your Bot
-
-You are finally ready to deploy your bot on the Cluster and get it running!
-
-To deploy your Bot, use the [`silverback cluster bots new`][silverback-cluster-bots-new] command and give your bot a name,
-container image, network to run on, an account alias (if you want to sign transactions w/ `bot.signer`),
-and any environment Variable Group(s) the bot needs.
-If everything validates successfully, the Cluster will begin orchestrating your deployment for you.
-
-You should monitor the deployment and startup of your bot to make sure it enters the RUNNING state successfully.
-You can do this using the [`silverback cluster bots health`][silverback-cluster-bots-health] command.
-
-```{note}
-It usually takes a minute or so for your bot to transition from PROVISIONING to STARTUP to the RUNNING state.
-If there are any difficulties in downloading your container image, provisioning your desired infrastructure, or if your bot encounters an error during the STARTUP phase,
-the Bot will not enter into the RUNNING state and will be shut down gracefully into the STOPPED state.
-
-Once in the STOPPED state, you can make any adjustments to the environment Variable Group(s) or other runtime parameters in the Bot config;
-or, you can make code changes and deploy a new image for the Bot to use.
-Once ready, you can use the `silverback cluster bots start` command to re-start your Bot.
-```
-
-If at any time you want to view the configuration of your bot, you can do so using the [`silverback cluster bots info`][silverback-cluster-bots-info] command.
-You can also update metadata or configuration of your bot using the [`silverback cluster bots update`][silverback-cluster-bots-update] command.
-Lastly, if you want to shutdown and delete your bot, you can do so using the [`silverback cluster bots remove`][silverback-cluster-bots-remove] command.
-
-```{note}
-Configuration updates do not redeploy your Bots automatically, you must manually stop and restart your bots for changes to take effect.
-```
-
-```{warning}
-Removing a Bot will immediately trigger a SHUTDOWN if the Bot is not already STOPPED.
-```
-
-## Monitoring your Bot
-
-Once your bot is successfully running in the RUNNING state, you can monitor your bot with a series of commands
-under the [`silverback cluster bots`][silverback-cluster-bots] subcommand group.
-We already saw how you can use the [`silverback cluster bots list`][silverback-cluster-bots-list] command to see all bots managed by your Cluster (running or not).
-
-To see runtime health information about a specific bot, again use the [`silverback cluster bots health`][silverback-cluster-bots-health] command.
-You can view the logs that a specific bot is generating using the [`silverback cluster bots logs`][silverback-cluster-bots-logs] command.
-Lastly, you can view unacknowledged errors that your bot has experienced while in the RUNNING state
-using the [`silverback cluster bots errors`][silverback-cluster-bots-errors] command.
-
-```{warning}
-Once in the RUNNING state, your Bot will not stop running unless it experiences a certain amount of errors in quick succession.
-Any task execution that experiences an error will abort execution (and therefore not produce any metrics) but the Bot **will not** shutdown.
-
-All errors encountered during task exeuction are reported to the Cluster for later review by any users with appriopiate access.
-Tasks do not retry (by default), but updates to `bot.state` are maintained up until the point an error occurs.
-
-It is important to keep track of these errors and ensure that none of them are in fact critical to the operation of your Bot,
-and to take corrective or preventative action if it is determined that it should be treated as a more critical failure condition.
-```
-
-```{note}
-Your Bots can also be monitored from the Platform UI at [https://silverback.apeworx.io](https://silverback.apeworx.io).
-```
-
-## Controlling your Bot
-
-As we already saw, once a Bot is configured in a Cluster, we can control it using commands from the [`silverback cluster bots`][silverback-cluster-bots] subcommand group.
-For example, we can attempt to start a Bot that is not currently running (after making configuration or code changes)
-using the [`silverback cluster bots start`][silverback-cluster-bots-start] command.
-We can also stop a bot using [`silverback cluster bots stop`][silverback-cluster-bots-stop] that is currently in the RUNNING state if we desire.
-
-```{note}
-Controlling your bots can be done from the Platform UI at [https://silverback.apeworx.io](https://silverback.apeworx.io), if you have the right permissions to do so.
-```
-
-TODO: Updating runtime parameters
-
-## Viewing Measured Metrics
-
-TODO: Downloading metrics from your Bot
-
+[distributed-execution]: ./advanced.html#distributed-execution
 [silverback-build]: ../commands/run.html#silverback-build
-[silverback-cluster-bots]: ../commands/cluster.html#silverback-cluster-bots
-[silverback-cluster-bots-errors]: ../commands/cluster.html#silverback-cluster-bots-errors
-[silverback-cluster-bots-health]: ../commands/cluster.html#silverback-cluster-bots-health
-[silverback-cluster-bots-info]: ../commands/cluster.html#silverback-cluster-bots-info
-[silverback-cluster-bots-list]: ../commands/cluster.html#silverback-cluster-bots-list
-[silverback-cluster-bots-logs]: ../commands/cluster.html#silverback-cluster-bots-logs
-[silverback-cluster-bots-new]: ../commands/cluster.html#silverback-cluster-bots-new
-[silverback-cluster-bots-remove]: ../commands/cluster.html#silverback-cluster-bots-remove
-[silverback-cluster-bots-start]: ../commands/cluster.html#silverback-cluster-bots-start
-[silverback-cluster-bots-stop]: ../commands/cluster.html#silverback-cluster-bots-stop
-[silverback-cluster-bots-update]: ../commands/cluster.html#silverback-cluster-bots-update
-[silverback-cluster-registry-new]: ../commands/cluster.html#silverback-cluster-registry-new
-[silverback-cluster-vars]: ../commands/cluster.html#silverback-cluster-vars
-[silverback-cluster-vars-info]: ../commands/cluster.html#silverback-cluster-vars-info
-[silverback-cluster-vars-list]: ../commands/cluster.html#silverback-cluster-vars-list
-[silverback-cluster-vars-new]: ../commands/cluster.html#silverback-cluster-vars-new
-[silverback-cluster-vars-remove]: ../commands/cluster.html#silverback-cluster-vars-remove

--- a/docs/userguides/development.md
+++ b/docs/userguides/development.md
@@ -2,76 +2,38 @@
 
 In this guide, we are going to show you more details on how to build an bot with Silverback.
 
-## Prerequisites
-
-You should have a python project with Silverback installed.
-You can install Silverback via `pip install silverback`
-
 ## Project structure
 
-There are 3 suggested ways to structure your project. In the root directory of your project:
+There are 3 suggested ways to structure your bot project.
+In the root directory of your project, do one of the following:
 
-1. Create a `bot.py` file. This is the simplest way to define your bot project.
+1. Create a `bot.py` file. This is the simplest way to define your bot project and is suggested if the bot implementation is the entire project you wish to build. You can then run it without adding any name to your command. (e.g. `silverback run --network ...`)
 
-2. Create a `bots/` folder. Then develop bots in this folder as separate scripts (Do not include a `__init__.py` file).
+2. Create a `bots/` folder. You can add multiple bots to this folder as separate scripts. This is the suggested way if the bots fit into a larger system or protocol design monorepo. You would need to add the selected bot's name in your commands. (e.g. `silverback run example --network ...`)
 
-3. Create a `bot/` folder with a `__init__.py` file that will include the instantiation of your `SilverbackBot()` object.
+3. Create a `bot/` python module, with a `__init__.py` in it. This is recommended if you have significant complex logic in your bot and wish to modularize more code under `bot/`. You will be able to run it without adding any name to your command. (e.g. `silverback run --network ...`)
 
-The `silverback` cli automatically searches for python scripts to run as bots in specific locations relative to the root of your project.
-It will also be able to detect the scripts inside your `bots/` directory and let you run those by name (in case you have multiple bots in your project).
-
-If `silverback` finds a module named `bot` in the root directory of the project, then it will use that by default.
+The `silverback` cli automatically searches for python scripts in these specific locations relative to the root of your project.
 
 ```{note}
-It is suggested that you create the instance of your `SilverbackBot()` object by naming the variable `bot`, since `silverback` will autodetect that variable name when loading your script file.
+If you have multiple bots, we suggest using the `bots/` folder approach as it easily supports multi-bot workflows.
+Silverback will automatically register files in this folder as separate bots that can be run via the `silverback run` command.
+This is especially useful for simulating a more complex protocol you are developing which requires multiple roles
+(that you wish to publish as bots).
+
+Treat this folder like a scripts folder: do not include an `__init__.py` in it.
 ```
 
-Another way you can structure your bot is to create a `bot` folder and define a runner inside of that folder as `__init__.py`.
-
-If you have a more complicated project that requires multiple bots, naming each bot their own individual name is okay to do, and we encourage you to locate them under the `bots/` folder relative to the root of your project.
-This will work fairly seamlessly with the rest of the examples shown in this guide.
-
-To run a bot, as long as your project directory follows the suggestions above by using a `bot` module, you can run it easily with:
-
-```bash
-silverback run --network your:network:of:choice
+```{important}
+Name your `SilverbackBot` instance `bot`.
+Silverback automatically searches for this object name when running.
+If you do not name it `bot`, ensure you add `:<instance name>` to your command.
+(e.g. `silverback run my_bot:my_instance --network ...`)
 ```
 
-If your bot's module name is `example.py` (for example), you can run it like this:
+## Bot Structure
 
-```bash
-silverback run example --network your:network:of:choice
-```
-
-If the variable that you call the `SilverbackBot()` object is something other than `bot`, you can specific that by adding `:{variable-name}`:
-
-```bash
-silverback run example:my_bot --network your:network:of:choice
-```
-
-We will automatically detect all scripts under the `bots/` folder automatically, but if your bot resides in a location other than `bots/` then you can use this to run it:
-
-```bash
-silverback run folder.example:bot --network your:network:of:choice
-```
-
-Note that with a `bot/__init__.py` setup, silverback will also autodetect it, and you can run it with:
-
-```bash
-silverback run --network your:network:of:choice
-```
-
-```{note}
-It is suggested that you develop your bots as scripts to keep your deployments simple.
-If you have a deep understanding of containerization, and have specific needs, you can set your bots up however you'd like, and then create your own container definitions for deployments to publish to your reqistry of choice.
-For the most streamlined experience, develop your bots as scripts, and avoid relying on local packages
-(e.g. do not include an `__init__.py` file inside your `bots/` directory, and do not use local modules inside `bots/` for reusable code).
-If you follow these suggestions, your Silverback deployments will be easy to use and require almost no thought.
-```
-
-## Creating a Bot
-
-Creating a Silverback Bot is easy, to do so initialize the `silverback.SilverbackBot` class:
+Creating a Silverback Bot is easy, simply import and initialize the `silverback.SilverbackBot` class:
 
 ```python
 from silverback import SilverbackBot
@@ -79,91 +41,161 @@ from silverback import SilverbackBot
 bot = SilverbackBot()
 ```
 
-The `SilverbackBot` class handles state and configuration.
-Through this class, we can hook up event handlers to be executed each time we encounter a new block or each time a specific event is emitted.
-Initializing the bot creates a network connection using the Ape configuration of your local project, making it easy to add a Silverback bot to your project in order to perform automation of necessary on-chain interactions required.
+The `SilverbackBot` class automatically handles state and configuration.
+Through this class we can hook up "event handlers",
+which are custom Python functions that are called each time the associated event occurs.
 
-However, by default an bot has no configured event handlers, so it won't be very useful.
+```{important}
+Initializing the `SilverbackBot` class creates a network connection using the local Ape configuration,
+making it easy to add a Silverback bot to your Ape project.
+It is required to put any global logic which requires a network connection
+(such as loading contracts using a connected explorer) after initializing this class.
+```
+
+By default a bot has no configured event handlers, so it won't be very useful.
 This is where adding event handlers is useful via the `bot.on_` method.
-This method lets us specify which event will trigger the execution of our handler as well as which handler to execute.
+This method lets us specify blockchain events that we want to handle with custom Python logic.
 
-## New Block Events
+### New Block Events
 
-To add a block handler, you will do the following:
+To add a handler that triggers whenever the connected network produces a new block,
+you need to do the following:
 
 ```python
 from ape import chain
+from silverback import SilverbackBot
+
+
+bot = SilverbackBot()
+
 
 @bot.on_(chain.blocks)
 def handle_new_block(block):
-    ...
+    ...  # Define your logic here
 ```
 
-Inside of `handle_new_block` you can define any logic that you want to handle each new `block` detected by the silverback client.
-You can return any serializable data structure from this function and that will be stored in the results database as a trackable metric for the execution of this handler.
+Inside of `handle_new_block` you can define any logic that you need to handle each new `block` created by the network.
 Any errors you raise during this function will get captured by the client, and recorded as a failure to handle this `block`.
 
-## New Event Logs
+```{important}
+Listening for new blocks is susceptible to chain re-organizations (aka "re-orgs").
+See [Handling Reorgs](./advanced.html#handling-reorgs) for more guidance on dealing with them.
+```
 
-Similarly to blocks, you can handle events emitted by a contract by adding an event handler:
+```{note}
+If needed, you can have multiple handlers that trigger on new blocks.
+Just add them as a new decorated function.
+```
+
+### New Event Logs
+
+Similarly to new blocks, you can handle when event logs emitted by a contract by adding an event log handler:
 
 ```python
 from ape import Contract
+from silverback import SilverbackBot
 
-TOKEN = Contract(<your token address here>)
+
+bot = SilverbackBot()
+TOKEN = Contract("<token address>")
+
 
 @bot.on_(TOKEN.Transfer)
-def handle_token_transfer_events(transfer):
-    ...
+def handle_token_transfer(log):
+    ...  # Define your logic here
 ```
 
-Inside of `handle_token_transfer_events` you can define any logic that you want to handle each new `transfer` event that gets emitted by `TOKEN.Transfer` detected by the silverback client.
-Again, you can return any serializable data structure from this function and that will be stored in the results database as a trackable metric for the execution of this handler.
-Any errors you raise during this function will get captured by the client, and recorded as a failure to handle this `transfer` event log.
+Inside of `handle_token_transfer` you can define any logic that you need to handle each new `Transfer` log emitted by `TOKEN`.
+Any errors you raise during this function will get captured by the client, and recorded as a failure to handle this `Transfer` log.
 
-### Event Log Filters
+```{important}
+Listening for contract event logs is susceptible to chain re-organizations (aka "re-orgs").
+See [Handling Reorgs](./advanced.html#handling-reorgs) for more guidance on dealing with them.
+```
 
-You can also filter event logs by event parameters.
-For example, if you want to handle only `Transfer` events that represent a burn (a transfer to the zero address):
+```{note}
+If needed, you can have multiple handlers that trigger on new event logs.
+Just add them as a new decorated function.
+```
+
+#### Event Log Filters
+
+You can also filter event logs by using event parameters.
+For example, if you only want to trigger on `Transfer` logs that represent a "burn"
+(a transfer to the zero address according to the ERC20 specification), then you can do:
 
 ```python
-@bot.on_(USDC.Transfer, to="0x0000000000000000000000000000000000000000")
+from ape.utils import ZERO_ADDRESS
+...
+
+
+@bot.on_(USDC.Transfer, to=ZERO_ADDRESS)
 def handle_burn(log):
-    return {"burned": log.value}
+    ...  # Define your logic here
 ```
 
-In case an event parameter has a name that is an illegal keyword, we can also support a dictionary syntax:
+In case an event parameter has the name of a Python keyword, we also support filtering by dict:
 
 ```python
-@bot.on_(USDC.Transfer, filter_args={"from":"0x0000000000000000000000000000000000000000"})
+@bot.on_(USDC.Transfer, filter_args={"from": ZERO_ADDRESS})
 def handle_burn(log):
-    return {"burned": log.value}
+    ...  # Define your logic here
 ```
 
-## Cron Tasks
+```{warning}
+Using filter args performs matching using **the loaded contract instance's ABI**,
+which could be different depending on your Ape environment and how you loaded the contract originally.
 
-You may also want to run some tasks according to a schedule, either for efficiency reasons or just that the task is not related to any chain-driven events.
-You can do that with the `@cron` task decorator.
+When in doubt, delete the corresponding entries from `~/.ape/<ecosystem>/<network>/**/<address>.json`.
+This is especially important when considering containerizing your bot for cloud use.
+```
+
+### Cron Tasks
+
+You may also want to run some handlers according to a schedule,
+either for efficiency reasons or just that the task is not related to any blockchain activity.
+You can do that easily with the `@bot.cron` task decorator:
 
 ```python
-@bot.cron("* */1 * * *")
-def every_hour():
-    ...
+@bot.cron("0 * * * *")
+def every_hour(time):
+    ...  # Define your logic here
 ```
 
-For more information see [the linux handbook section on the crontab syntax](https://linuxhandbook.com/crontab/#understanding-crontab-syntax) or the [crontab.guru](https://crontab.guru/) generator.
+```{important}
+The function is called by giving a `datetime.datetime` object representing the "current" time.
+Silverback bots can be executed in a "historical mode" (for backtesting purposes),
+allowing you to test functionality of your bot by mimicking past operation on historical data.
+It is important to use this argument for any time-specific operation in your handler,
+and not use context-dependent functionality like `datetime.now()` which could bias your response.
+```
 
-## Defining Metrics
+```{note}
+For more information on desiging crons, see the
+[linux handbook for crontab syntax](https://linuxhandbook.com/crontab/#understanding-crontab-syntax)
+or the [crontab.guru](https://crontab.guru) generator.
+```
 
-Silverback has a built-in metrics collection system which can capture measurements made by your bots, which can assist you in debugging or performance monitoring.
-To capture a measurement of a metric datapoint, simply return boolean values or numeric data from your function handlers, or use any of our defined [Datapoint types](../methoddocs/types).
-When you return a datapoint measurement directly, the datapoint is stored using the label of it's function handler to append to a timeseries for the metric.
-When you return a dictionary containing multiple measurements, the string key corresponds to label of the metric you are capturing a datapoint for.
+### Defining Metrics
 
-Note that metric labels are tracked globally across your bot.
-If you generate metrics in two different function handlers that have the same string keys in the dictionary, they will both be appended to the same metric timeseries.
+Silverback has a built-in metrics collection system which lets you capture measurements of important metrics using your bot,
+which can assist you in a variety of tasks such as debugging or monitoring it's performance.
+To capture a measurement, simply return boolean values or numeric values from your function handlers,
+or use any of our supported [Datapoint types](../methoddocs/types.html#silverback.types.Datapoint).
+The series of metric measurements will also be captured and appended to a timeseries, when enabled to run in this mode.
 
-For example, both of the following handlers `handlerA` and `handlerB` generate the `block_time` metric, along with the `block_time` handler which also generates a matching metric of the same name (because it does not return a dict):
+```{important}
+Metrics are tracked globally across your bot.
+If you generate metric measurements in two different function handlers using the same metric name,
+they will both be appended to the same metric timeseries.
+```
+
+When you return a datapoint measurement directly, the metric's name is the name of the function handler that produced it.
+However, when you return a dictionary containing multiple measurements,
+the string key corresponds to metric's name you are capturing a datapoint for.
+
+For example, both of the following handlers `handlerA` and `handlerB` generate the `block_time` metric,
+along with the `block_time` handler which also generates a matching metric of the same name (because it does not return a dict):
 
 ```python
 @bot.on_(my_contract.MyEvent)
@@ -179,9 +211,11 @@ async def block_time(block):
     return block.timestamp
 ```
 
-### Metric Callbacks
+This can be really useful if you have a complex metric which might occur under several conditions.
 
-A special feature of Silverback's metrics system is the ability to trigger tasks to execute when your metrics are produced.
+#### Metric Callbacks
+
+A special feature of Silverback's metrics system is the ability to trigger tasks to execute when new measurements are produced.
 For example, say that you have a metric `current_price` that is computed every so often using a `cron` task trigger:
 
 ```python
@@ -191,7 +225,7 @@ async def current_price(time):
     return current_price
 ```
 
-You can then define a metric callback that is triggered whenever that metric is produced:
+You can then define a "metric callback" that is triggered whenever a new measurement of that metric occurs:
 
 ```python
 @bot.on_metric("current_price")
@@ -199,8 +233,8 @@ async def on_current_price(current_price: float):
     ...  # Do something with the price
 ```
 
-This can be particularly handy for definining conditions that trigger whenever a metric is conditionally produced.
-Let's say that you want to record a metric `pool_delta` whenever a particular trade is made using an event trigger:
+This can be particularly handy for definining conditions that trigger whenever a metric has been measured conditionally.
+Let's say that you want to measure a metric `pool_delta` only when a trade is made in another handler:
 
 ```python
 @bot.on_(pool.Swap)
@@ -209,7 +243,7 @@ async def check_pool_balance(log):
         return dict(pool_delta=log.reserve0 - log.reserve1)
 ```
 
-Then you want to trigger off of that metric, but only if it's value is _larger than a threshold_.
+Then you want to trigger off updates to that metric, but only if a measurement is _larger than a threshold_.
 We can use `gt=<threshold>` to do this:
 
 ```python
@@ -221,52 +255,23 @@ async def perform_rebalance(pool_delta: int):
 ```{note}
 `.on_metric` supports 6 different value comparisons (`gt`, `ge`, `lt`, `le`, `ne`, and `eq`).
 When multiple comparisons are present, they are treated as a logical AND (meaning they must all be true for the task to execute).
-If you need a separate task to execute on different compound conditions, simply define extra tasks.
+If you need a separate task to execute on different compound conditions, simply define extra handlers.
 ```
 
-## Startup and Shutdown
+### Bot Lifecycle Events
 
-### Worker Events
+In addition to "runtime triggers" (new blocks, event logs, crons, and metric callback triggers),
+we also have the ability to trigger on bot startup and shutdown.
 
-If you have heavier resources you want to load during startup, or want to initialize things like database connections, you can add a worker startup function like so:
-
-```python
-@bot.on_worker_startup()
-def handle_on_worker_startup(state):
-    # Connect to DB, set initial state, etc
-    ...
-
-@bot.on_worker_shutdown()
-def handle_on_worker_shutdown(state):
-    # cleanup resources, close connections cleanly, etc
-    ...
+```{note}
+Bot lifecycle and bot runtime triggers are handled distinctly and can be trusted not to execute at the same time.
 ```
 
-This function comes a parameter `state` that you can use for storing the results of your startup computation or resources that you have provisioned.
+#### Bot Startup and Shutdown
 
-It's import to note that this is useful for ensuring that your workers (of which there can be multiple) have the resources necessary to properly handle any updates you want to make in your handler functions, such as connecting to the Telegram API, an SQL or NoSQL database connection, or something else. **This function will run on every worker process**.
-
-_New in 0.2.0_: These events moved from `on_startup()` and `on_shutdown()` for clarity.
-
-#### Worker State
-
-The `state` variable is also useful as this can be made available to each handler method so other stateful quantities can be maintained for other uses. Each distributed worker has its own instance of state.
-
-To access the state from a handler, you must annotate `context` as a dependency like so:
-
-```python
-from typing import Annotated
-from taskiq import Context, TaskiqDepends
-
-@bot.on_(chain.blocks)
-def block_handler(block, context: Annotated[Context, TaskiqDepends()]):
-    # Access state via context.state
-    ...
-```
-
-### Bot Events
-
-You can also add an bot startup and shutdown handler that will be **executed once upon every bot startup**. This may be useful for things like processing historical events since the bot was shutdown or other one-time actions to perform at startup.
+You can add a handler that you want to be **executed only once** upon every bot startup or shutdown lifecycle event.
+This might be useful for things like backfilling historical data to prime the bot's operation,
+or performing a final action like sending a notification or transaction to undo a potentially dangerous offline state.
 
 ```python
 @bot.on_startup()
@@ -274,153 +279,163 @@ def handle_on_startup(startup_state):
     # Process missed events, etc
     # process_history(start_block=startup_state.last_block_seen)
     # ...or startup_state.last_block_processed
-    ...
 
 
 @bot.on_shutdown()
 def handle_on_shutdown():
-    # Record final state, etc
-    ...
+    # Record final state, send a de-leverage transaction, etc.
 ```
 
-_Changed in 0.2.0_: The behavior of the `@bot.on_startup()` decorator and handler signature have changed. It is now executed only once upon bot startup and worker events have moved on `@bot.on_worker_startup()`.
+```{important}
+`.on_startup()` handlers will **only trigger once** during the startup sequence,
+and any failures will cause the bot not to transition into the runtime mode.
+```
 
-## Bot State
+```{note}
+`.on_shutdown()` handlers will **only trigger once** during the shutdown sequence,
+which only executes if the bot was previously in the runtime mode.
+Any failures that occur will **not** impact the shutdown of the bot in any way.
+```
 
-Sometimes it is very useful to have access to values in a shared state across your workers.
-For example you might have a value or complex reference type that you wish to update during one of your tasks, and read during another.
+### Bot State
+
+Sometimes it is very useful to have access to values in a shared state across your bot.
+For example you might have a value that you wish to update during execution of one of your handlers,
+and then read during the execution of another.
 Silverback provides `bot.state` to help with these use cases.
 
-For example, you might want to pre-populate a large dataframe into state on startup, keeping that dataframe in sync with the chain through event logs,
-and then use that data to determine a signal under which you want trigger transactions to commit back to the chain.
+For example, you might want to pre-populate a large dataframe into state using a startup handler,
+keep that dataframe in sync with the chain through several event log handlers,
+and then process that data to produce a custom metric every couple of minutes,
+which may trigger sending a transaction.
+
 Such an bot might look like this:
 
 ```python
 @bot.on_startup()
-def create_table(startup_state):
-    df = contract.MyEvent.query(..., start_block=startup_state.last_block_processed)
-    ...  # Do some further processing on df
-    bot.state.table = df
+def load_df(startup_state):
+    bot.state.df = contract.MyEvent.query(..., start_block=startup_state.last_block_processed)
+    ...  # Do some further processing on `bot.state.df`
 
 
 @bot.on_(contract.MyEvent)
-def update_table(log):
-    bot.state.table = ...  # Update using stuff from `log`
+def update_df(log):
+    bot.state.df.loc[-1] = ...  # Add a row using stuff from `log`
 
 
-@bot.on_(chain.blocks)
-def use_table(blk):
-    if bot.state.table[...].mean() > bot.state.table[...].sum():
-        # Trigger your bot to send a transaction from `bot.signer`
-        contract.myMethod(..., sender=bot.signer)
-    ...
+@bot.cron("0 * * * *")
+def measure_metric(time):
+    metric = ...  # Use `bot.state.df` to produce a metric
+    return {"metric": metric}
+
+
+@bot.on_metric("metric", gt=MIN_THRESHOLD)
+def use_table(metric):
+    # Trigger your bot to send a transaction from `bot.signer`
+    contract.myMethod(..., sender=bot.signer)
 ```
 
 ```{warning}
-You can use `bot.state` to store any python variable type, however note that the item is not networked nor threadsafe so it is not recommended to have multiple tasks write to the same value in state at the same time.
-```
-
-```{note}
-Bot startup and bot runtime event triggers (e.g. block or event container) are handled distinctly and can be trusted not to execute at the same time.
+While you can use `bot.state` to store any python variable type,
+note that the item is not networked nor threadsafe,
+so it is not recommended to have multiple tasks write to the same value in state at the same time.
 ```
 
 ### Signing Transactions
 
 If configured, your bot with have `bot.signer` which is an Ape account that can sign arbitrary transactions you ask it to.
-To learn more about signing transactions with Ape, see the [documentation](https://docs.apeworx.io/ape/stable/userguides/transactions.html).
-
-```{warning}
-While not recommended, you can use keyfile accounts for automated signing.
-See [this guide](https://docs.apeworx.io/ape/stable/userguides/accounts.html#automation) to learn more about how to do that.
-```
-
-### Managing nonces
-
-Since Silverback allows handling many events in parallel, and thus can allow you to submit multiple transactions in a short timespan (in fact, prior to successful confirmation of previously broadcasted transactions), it may become vital to do "nonce management" in order to ensure that you are not producing transactions that might conflict with one another.
-The `bot.nonce` variable tracks the last-used nonce of the `bot.signer`, incrementing it every time a new transaction is signed _during the bot's operation_.
-By using this variable via `nonce=bot.nonce` in your transactions (instead of `bot.signer.nonce`, which is the default behavior when the `nonce=` transaction kwarg is omitted), you can ensure that you do not produce transactions with conflicting nonces, even at a very high rate of parallel transaction creation.
-
-```{note}
-The value of `bot.nonce` is the maximum between the internally-stored "last-used nonce", and the value given by RPC method
-```
-
-```{warning}
-Make sure to use an appropiate gas pricing algorithm in order to prevent your chain of multiple transactions from becoming "stuck" because an earlier broadcasted transaction was under-priced
-```
-
-```{warning}
-Do *not* use the same account on the same network at the same time as the one in use by your bot, as this could lead to extremely undesirable behavior, stuck transactions, or transaction failures/loss of funds
-```
-
-## Cluster Access
-
-Sometimes, there are scenarios where you want to create a bot that has the capability to control other bots.
-This might make sense if you are having one bot that monitors a particular contract and interacts with all their events,
-and a version of that contract is deployed by another Factory contract.
-Another example is if you want a bot that monitors the performance of another bot,
-and then stops it if it discovers any issues encountered while monitoring it.
-
-Creating this type of setup allows a sort of "agentic scaling" where you can quickly scale up your bot cluster's
-on-chain "footprint" and cover more ground by having multiple other bots handling situations you encounter.
-This also can more effectively distribute the cluster load when you have large quantities of events to be handled,
-and need to dynamically scale in order to add more capacity in response to on-chain conditions.
-
-```py
-@bot.on_(factory.NewPool)
-async def deploy_arb_bot(log):
-    vg = bot.cluster.new_variable_group(
-        name=f"{log.token0}-{log.token1}-pool",
-        variables={"POOL": log.pool_address},
-    )
-    bot = bot.cluster.new_bot(
-        name=f"{log.token0}-{log.token1}-arb",
-        ...,
-        environment=[vg.name, ...],
-    )
-```
+To learn more about signing transactions with Ape,
+see the [documentation](https://docs.apeworx.io/ape/stable/userguides/transactions.html).
 
 ```{important}
-Testing cluster access is not practical without deploying on the [Silverback Platform](./platform.html).
-The cluster implements additional authorization checks based on the `--cluster-access` flag provided
-with the [`silverback cluster bots new`](../commands/cluster#silverback-cluster-bots-new)
-and [`silverback cluster bots update`](../commands/cluster#silverback-cluster-bots-update) commands.
+For local development, you can use keyfile accounts for automated signing.
+Silverback will prompt you to unlock the keyfile and then set "autosign" mode, which will sign all transactions your bot triggers.
+See [this guide](https://docs.apeworx.io/ape/stable/userguides/accounts.html#automation) to learn more about autosign mode.
 ```
 
-_Added in Silverback SDK [v0.7.35](https://github.com/ApeWorX/silverback/releases/tag/v0.7.35)_
-_Support added in Silverback Cluster [v0.7.0](https://silverback.apeworx.io/changelog#cluster-v0-7-0)_
+```{danger}
+For cloud deployment, it is **not** recommended to use keyfile accounts.
+Instead, it is recommended to use a dedicated cloud signer plugin such as [`aws`](https://github.com/ApeWorX/ape-aws).
+
+Using keyfiles in a cloud setting could lead to **permanent fund loss** if the keyfile (and it's passphrase) leak,
+and it is also not very helpful for others wishing to run your bots.
+Using a dedicated service-based signer plugin adds extra security to your deployment,
+and makes it possible for anyone to run your bot by bringing **their managed own keys**.
+```
+
+#### Managing nonces
+
+Since Silverback allows handling many events in parallel,
+it can allow you to submit multiple transactions in a short timespan
+(in fact, prior to successful confirmation of previously broadcasted transactions)
+It may become vital to do "nonce management" in order to ensure that you are not producing transactions
+that might conflict with one another.
+
+The `bot.nonce` variable tracks the last-used nonce of the `bot.signer`,
+incrementing it every time a new transaction is signed _during the bot's operation_.
+By using this variable (via `nonce=bot.nonce` in your transactions),
+you can ensure that you do not produce transactions with conflicting nonces,
+even at a very high rate of parallel transaction creation.
+Do this instead of using `bot.signer.nonce`, which is the default behavior when the `nonce=` transaction kwarg is omitted.
+
+```{note}
+The value of `bot.nonce` is the maximum between the internally-stored "last-used nonce",
+and the value given by `eth_getNonce` RPC method, so it should never get "out of sync" in practice.
+```
+
+```{warning}
+Make sure to use appropiate gas pricing in order to prevent chains of multiple transactions
+from becoming "stuck", because an earlier broadcasted transaction was under-priced.
+```
+
+```{danger}
+Do *not* use the same account on the same network at the same time as the one in use by your bot,
+as this could lead to extremely undesirable behavior, stuck transactions, transaction failures,
+or **loss of funds**.
+```
 
 ## Running your Bot
 
-Once you have programmed your bot, it's really useful to be able to run it locally and validate that it does what you expect it to do.
-To run your bot locally, we have included a really useful cli command [`run`](../commands/run) that takes care of connecting to the proper network, configuring signers (using your local Ape accounts), and starting up the bot client and in-memory task queue workers.
+Once you have programmed your bot,
+it's really useful to be able to run it locally and validate that it does what you expect it to do.
+To run your bot locally, we have included the cli command [`run`](../commands/run)
+that takes care of connecting to the proper network, configuring signers (using your local Ape accounts),
+and starting up the bot runtime and worker clients.
 
 ```sh
-# Run your bot on the Ethereum Sepolia testnet, with your own signer:
-$ silverback run my_bot --network :sepolia --account acct-name
+# Run `bot.py` on the Ethereum Sepolia testnet, with your own signer:
+$ silverback run --network :sepolia --account acct-name
 ```
 
 ```{note}
-`my_bot:bot` is not required for silverback run if you follow the suggested folder structure at the start of this page, you can just call it via `my_bot`.
+`bot:bot` is not required for silverback run if you follow the suggested folder structure at the start of this page,
+you can just omit it as an argument.
 ```
 
 It's important to note that signers are optional, if not configured in the bot then `bot.signer` will be `None`.
 You can use this in your bot to enable a "test execution" mode, something like this:
 
 ```python
-# Compute some metric that might lead to creating a transaction
-if bot.signer:
-    # Execute a transaction via `sender=bot.signer`
-else:
-    # Log what the transaction *would* have done, had a signer been enabled
+@bot.on_metric("metric-name", gt=THRESHOLD)
+def execute_trade(metric):
+    if bot.signer:
+        ... # Execute a transaction via `sender=bot.signer`
+
+    else:
+        ... # simulate what the transaction *would* have done
 ```
 
 ```{warning}
-If you configure your bot to use a signer, and that signer signs anything given to it, remember that you can lose substational amounts of funds if you deploy this to a production network.
-Always test your bots throughly before deploying, and always use a dedicated key for production signing with your bot in a remote setting.
+If you configure your bot to use a signer, that signer will sign anything given to it,
+so remember that you can lose substational amounts of funds if you deploy this to a production network.
+
+Always test your bots throughly before deploying, and always use a dedicated key for production use with proper safety precautions.
 ```
 
-```{note}
-It is highly suggested to use a dedicated cloud signer plugin, such as [`ape-aws`](https://github.com/ApeWorX/ape-aws) for signing transactions in a cloud environment.
+```{danger}
+It is highly suggested to use a dedicated cloud signer plugin,
+such as [`ape-aws`](https://github.com/ApeWorX/ape-aws) for signing transactions in a cloud environment.
+
 Use segregated keys and limit your risk by controlling the amount of funds that key has access to at any given time.
 ```
 
@@ -429,26 +444,31 @@ Use segregated keys and limit your risk by controlling the amount of funds that 
 It is important to note that when running your bot with Silverback,
 a failure in one of your tasks while running **does not necessarily cause it to shutdown immediately**.
 This is done to support handling occasional failures and unexpected scenarios that might happen during the runtime of your bot in practice.
+
 The way it works is that during runtime (after the startup phase has completed successfully),
 the silverback runner will track the number of failures that occurs in _any_ task;
 and, if there is more than the configured amount of exceptions occuring across all of your tasks,
-only then will trigger a runtime Halt that will stop your bot from running (and trigger your shutdown tasks).
+only then will it Halt the runtime mode and stop your bot from running (as well as trigger your shutdown handlers).
 
-You can configure this behavior when running with the [`silverback run ...`](../commands/run#silverback-run) command by changing the value of the `--max-exceptions` option.
+You can configure this behavior when running with the [`silverback run ...`](../commands/run#silverback-run)
+command by changing the value of the `--max-exceptions` option.
 A higher number will take more failures in order to trigger a complete shutdown of the bot,
-whereas a lower number will make it more sensistive to intermittent failures you are likely to find in practice.
-The default is chosen as a good balance between sensitivity and operational robustness.
+whereas a lower number will make it more sensistive to intermittent failures you are likely to find in production use.
+The default is chosen as a good balance between error sensitivity and operational robustness.
 
 ```{warning}
-Any failures that occur in **any of your startup tasks** (including system-level startup tasks internal to the SDK) will cause an immediate failure,
-and prevent the bot from transitioning into runtime mode, where failure persistence becomes active.
+Any failures that occur in **any of your startup tasks** (including system-level startup tasks internal to the SDK)
+will cause an immediate failure, and prevent the bot from transitioning into runtime mode,
+where failure persistence monitoring becomes active.
 ```
 
 This error tracking behavior in the runtime mode will occur handling any Python exception that your code is likely to raise.
-However, by raising the [`CircuitBreaker`](../methoddocs/exceptions#silverback.exceptions.CircuitBreaker) exception (or a subclass of it),
-you can cause your bot to **immediately shutdown** in response to application-specific faults you might detect.
-This might be useful if you know of a situation or invariant that you want to make sure to maintain during the operation of your bot no matter what,
-or if you detect that you no longer wish to run the bot any more for any desired reason (and want to handle it programmatically).
+However, by raising a [`CircuitBreaker`](../methoddocs/exceptions#silverback.exceptions.CircuitBreaker) exception
+(or a subclass of it), you can cause your bot to **immediately shutdown** in response to an application-specific fault.
+
+This might be useful if you know of a situation or invariant that you want to make sure to maintain
+during the operation of your bot no matter what, or if you detect that you no longer wish to run the
+bot any more for any desired reason (and want to handle it programmatically).
 
 ```{note}
 Any failures detected during shutdown tasks do not prevent the execution of any other shutdown tasks
@@ -456,8 +476,9 @@ Any failures detected during shutdown tasks do not prevent the execution of any 
 ```
 
 Lastly, you can insert a request during runtime to kill your bot manually by performing `ctrl+C`,
-or by sending a SIGTERM or SIGINT signal to the runtime process.
-This will trigger the same halting behavior immediately triggering your bot to move into the shutdown mode, and execute all shutdown tasks before exiting.
+or by sending a SIGTERM or SIGINT signal to the runtime process (from your task manager or orchestration runtime).
+This will trigger the same halting behavior immediately triggering your bot to move into the shutdown mode,
+and execute all shutdown tasks before exiting the process completely.
 
 ### Metrics Collection
 
@@ -474,49 +495,3 @@ You can supply a custom class for recording via the `--recorder <path.to.module:
 or by supplying the `SILVERBACK_RECORDER_CLASS=<path.to.module:ClassName>` environment variable.
 All recorders should be a subclass of the [`BaseRecorder`](../methoddocs/recorder#silverback.recorder.BaseRecorder)
 abstract base class.
-
-### Distributed Execution
-
-Using only the `silverback run ...` command in a default configuration executes everything in one process and the job queue is completely in-memory with a shared state.
-In some high volume environments, you may want to deploy your Silverback bot in a distributed configuration using multiple processes to handle the messages at a higher rate.
-
-The primary components are the client and workers. The client handles Silverback events (blocks and contract event logs) and creates jobs for the workers to process in an asynchronous manner.
-
-For this to work, you must configure a [TaskIQ broker](https://taskiq-python.github.io/guide/architecture-overview.html#broker) capable of distributed processing.
-Additonally, it is highly suggested you should also configure a [TaskIQ result backend](https://taskiq-python.github.io/guide/architecture-overview.html#result-backend) in order to process and store the results of executing tasks.
-
-```{note}
-Without configuring a result backend, Silverback may not work as expected since your tasks will now suddenly return `None` instead of the actual result.
-```
-
-For instance, with [`taskiq_redis`](https://github.com/taskiq-python/taskiq-redis) you could do something like this for the client:
-
-```bash
-export SILVERBACK_BROKER_CLASS="taskiq_redis:ListQueueBroker"
-export SILVERBACK_BROKER_KWARGS='{"queue_name": "taskiq", "url": "redis://127.0.0.1:6379"}'
-export SILVERBACK_RESULT_BACKEND_CLASS="taskiq_redis:RedisAsyncResultBackend"
-export SILVERBACK_RESULT_BACKEND_URI="redis://127.0.0.1:6379"
-
-silverback run --network :mainnet:alchemy
-```
-
-And then the worker process with 2 worker subprocesses:
-
-```bash
-export SILVERBACK_BROKER_CLASS="taskiq_redis:ListQueueBroker"
-export SILVERBACK_BROKER_KWARGS='{"url": "redis://127.0.0.1:6379"}'
-export SILVERBACK_RESULT_BACKEND_CLASS="taskiq_redis:RedisAsyncResultBackend"
-export SILVERBACK_RESULT_BACKEND_URI="redis://127.0.0.1:6379"
-
-silverback worker -w 2
-```
-
-The client will send tasks to the 2 worker subprocesses, and all task queue and results data will be go through Redis.
-
-## Testing your Bot
-
-TODO: Add backtesting mode w/ `silverback test`
-
-## Deploying your Bot
-
-Check out the [Platform Deployment Userguide](./platform.html) for more information on how to deploy your bot to the [Silverback Platform](https://silverback.apeworx.io).

--- a/docs/userguides/managing.md
+++ b/docs/userguides/managing.md
@@ -1,39 +1,47 @@
 # Silverback Platform
 
-In this guide, we are going to show you more details on how to deploy and host your bots in the cloud with the [Silverback Platform](https://silverback.apeworx.io).
+In this guide, we are going to show you more details on how to deploy and host your bots
+in the cloud with the [Silverback Platform](https://silverback.apeworx.io).
 
 ```{note}
 The Platform UI will let you create and manage Workspaces and Clusters using a graphical experience, which may be preferred.
 The CLI experience is for those working locally who don't want to visit the website, or for use locally when developing bots.
+It can also be used directly by an LLM, but we recommend using the [Model Context Server][#model-context-server] instead.
 ```
 
-Once you have signed up, you can actually create (and pay for) your Clusters from the Silverback CLI utility by first
-logging in to the Platform using [`silverback login`][silverback-login].
+## Requirements
+
+If you haven't already signed up, please visit [https://silverback.apeworx.io](https://silverback.apeworx.io) and sign up first.
+Then log in to the Platform using [`silverback login`][silverback-login] from the CLI command.
 
 ## Managing a Workspace
 
-A Workspace is an area for one or more people to co-manage a set of clusters together.
+A Workspace is an area for one or more users to co-manage a set of clusters together.
 You can manage workspaces from the Silverback CLI using [`silverback cluster workspaces`][silverback-cluster-workspaces].
 
-Using the Silverback CLI you can [list workspaces][silverback-cluster-workspaces-list], [make new ones][silverback-cluster-workspaces-new], [view their configuration information][silverback-cluster-workspaces-info], [update that information][silverback-cluster-workspaces-update], as well as [delete them][silverback-cluster-workspaces-delete].
+Using the Silverback CLI you can [`list` workspaces][silverback-cluster-workspaces-list], [make `new` ones][silverback-cluster-workspaces-new], [view their configuration `info`rmation][silverback-cluster-workspaces-info], [`update` that information][silverback-cluster-workspaces-update], as well as [`delete` them][silverback-cluster-workspaces-delete].
 
 ```{note}
 You need at least one workspace to deploy a cluster.
 It is recommended that you create a personal workspace first.
 ```
 
-## Managing a Cluster
+## Creating a Cluster
 
 The Silverback Platform runs your Bots on dedicated Clusters.
-These Clusters will take care to orchestrate infrastructure, monitor, run triggers, and collect metrics for all of your bots you have added to them.
-Each Cluster is run on bespoke infrastructure, which isolates your bots from those of other users by virtue of running in a segregated deployment.
+These Clusters will take care to orchestrate infrastructure, monitor, run triggers,
+and collect metrics for all of your bots you have added to them.
+Each Cluster is run on bespoke infrastructure, which isolates your bots from those of other users
+by virtue of running in a segregated deployment.
 
-Once you have a workspace, you can create new Clusters from the Silverback CLI using [`silverback cluster new`][silverback-cluster-new].
+Once you have a workspace, you can create new Clusters from the Silverback CLI using
+the [`silverback cluster new`][silverback-cluster-new] command.
 Just follow the steps it gives you to finish deploying it, and (if needed) pay for it.
 
-You can also use the Silverback CLI to [list][silverback-cluster-list] and [update][silverback-cluster-update] existing clusters.
+You can also use the Silverback CLI to [`list`][silverback-cluster-list]
+and [`update`][silverback-cluster-update] existing clusters.
 
-### Deploying a Cluster
+### Paying for a Cluster
 
 Once you have created your Cluster, you will likely have to fund it so it is made available for your use.
 To do that, use the [`silverback cluster pay create`][silverback-cluster-pay-create] command to fund your newly created cluster.
@@ -45,22 +53,175 @@ command to extend the timeline that the Cluster is hosted for.
 Note that it is possible for anyone to add more time to the Cluster, at any time and for any amount.
 
 ```{important}
-If that hosting time expires, the Platform will automatically de-provision your infrastructure. **It is not possible to reverse this!**
-The Platform may send you notifications when your Stream is close to expiring, but it is up to you to remember to fill it so it doesn't expire.
-Note that your collected data will stay available for up to 30 days allowing you the ability to download any data you need after it's been removed.
+If that hosting time expires, the Platform will automatically de-provision your infrastructure.
+**It is not possible to reverse this!**
+The Platform may send you notifications when your Stream is close to expiring,
+but it is up to you to remember to fill it so it doesn't expire.
+Note that your collected data will stay available for up to 30 days allowing you the ability
+to download any data you need after it's been removed.
 ```
 
-Lastly, if you ever feel like you want to delete your Cluster, you can cancel the funding for it and instantly get a refund for the remaining time.
-If you are the owner of the Stream, you can do this via the [`silverback cluster pay cancel`][silverback-cluster-pay-cancel] command.
+Lastly, if you ever feel like you want to delete your Cluster, you can cancel the funding for it
+and instantly get a refund for the remaining time!
+If you are the owner of the Stream, you can do this via the
+[`silverback cluster pay cancel`][silverback-cluster-pay-cancel] command.
 
-```{note}
+```{important}
 Only the owner may do this, so if you are not the owner you should contact them to have them do that action for you.
 ```
 
+## Adding Environment Variables
+
+Before adding bots, you might know of some environment variables they require to run properly.
+Thanks to it's flexible plugin system, ape plugins may also require specific environment variables to function as well.
+Silverback Clusters include an environment variable management system for exactly this purpose,
+which you can manage using [`silverback cluster vars`][silverback-cluster-vars] subcommand.
+
+The environment variable management system makes use of a concept called "Variable Groups",
+which are distinct collections of environment variables meant to be used together.
+These variable groups will help in managing the runtime environment of your Bots by allowing
+you to segregate different variables depending on each bot's needs.
+
+To create an environment group, use the [`silverback cluster vars new`][silverback-cluster-vars-new]
+command and give it a name and a set of related variables.
+For instance, it may make sense to make a group of variables for your favorite Ape plugins or services,
+such as RPC Providers, Blockchain Data Indexers, Etherscan, etc.
+You might also have a database connection that you want all your bots to access.
+
+```{warning}
+All environment variables in Silverback Clusters are private,
+meaning they cannot be viewed after they are uploaded.
+However, your Bots will have full access to their values from within their runtime environment,
+so be careful that you fully understand what you are sharing with your bots in each variable group.
+
+**NEVER** upload a private key in a plaintext format!
+
+Use _Ape Account Plugins_ such as [`ape-aws`](https://github.com/ApeWorX/ape-aws) to safely manage access to your hosted keys.
+```
+
+```{note}
+The Etherscan plugin _will not function_ without an API key in the cloud environment.
+This will likely create errors running your bots if you use Ape's `Contract` class.
+```
+
+To list existing Variable Groups, use [`silverback cluster vars list`][silverback-cluster-vars-list].
+To see information about a specific Variable Group, including the Environment Variables it includes,
+use [`silverback cluster vars info`][silverback-cluster-vars-info]
+To remove a variable group, use [`silverback cluster vars remove`][silverback-cluster-vars-remove].
+
+```{important}
+You can only remove a Variable Group if it is not referenced by any existing Bot.
+```
+
+Once you have created all the Variable Group(s) that you need to operate your Bot,
+you can reference these groups by name when adding your Bot to the cluster.
+
+## Private Container Registries
+
+If you are using a private container registry to store your images,
+you will need to provide your bot with the necessary credentials to access it.
+First you will need to add your credentials to the cluster with the
+[`silverback cluster registry new`][silverback-cluster-registry-new] command.
+
+Once added, the Cluster will automatically use these credentials when fetching private images.
+
+## Deploying your Bot
+
+You are finally ready to deploy your bot on the Cluster and get it running!
+
+To deploy your Bot, use the [`silverback cluster bots new`][silverback-cluster-bots-new] command and give your bot a name,
+container image, network to run on, an account alias (if you want to sign transactions w/ `bot.signer`),
+and any environment Variable Group(s) the bot needs to function (Etherscan, RPC API Key, etc.).
+If everything validates successfully, the Cluster will begin orchestrating your deployment for you.
+
+You should monitor the deployment and startup of your bot to make sure it enters the RUNNING state successfully.
+You can do this using the [`silverback cluster bots health`][silverback-cluster-bots-health] command.
+
+```{important}
+It usually takes a minute or so for your bot to transition from PROVISIONING to STARTUP to the RUNNING state.
+If there are any difficulties in downloading your container image, provisioning your desired infrastructure,
+or if your bot encounters an error during the STARTUP phase,
+the Bot will not enter into the RUNNING state and will be shut down gracefully into the STOPPED state.
+
+Once in the STOPPED state, you can make any adjustments to the environment Variable Group(s)
+or other runtime parameters in the Bot config; or, you can make code changes and deploy a new image for the Bot to use.
+Once ready, you can use the `silverback cluster bots start` command to re-start your Bot.
+```
+
+If at any time you want to view the configuration of your bot, you can do so using the
+[`silverback cluster bots info`][silverback-cluster-bots-info] command.
+You can also update metadata or configuration of your bot using the
+[`silverback cluster bots update`][silverback-cluster-bots-update] command.
+Lastly, if you want to shutdown and delete your bot, you can do so using the
+[`silverback cluster bots remove`][silverback-cluster-bots-remove] command.
+
+```{important}
+Configuration updates do not redeploy your Bots automatically,
+you must manually stop and restart your bots for changes to take effect.
+This is done so that you have full control over when this happens.
+```
+
+```{warning}
+Removing a Bot will immediately trigger a SHUTDOWN if the Bot is not already STOPPED.
+```
+
+## Monitoring your Bot
+
+Once your bot is successfully running in the RUNNING state,
+you can monitor your bot with a series of commands under the
+[`silverback cluster bots`][silverback-cluster-bots] subcommand group.
+We already saw how you can use the [`silverback cluster bots list`][silverback-cluster-bots-list]
+command to see all bots managed by your Cluster (running or not).
+
+To see runtime health information about a specific bot, again use the
+[`silverback cluster bots health`][silverback-cluster-bots-health] command.
+You can view the logs that a specific bot is generating using the
+[`silverback cluster bots logs`][silverback-cluster-bots-logs] command.
+Lastly, you can view unacknowledged errors that your bot has experienced while in the RUNNING state
+using the [`silverback cluster bots errors`][silverback-cluster-bots-errors] command.
+
+```{warning}
+Once in the RUNNING state, your Bot will not stop running unless it experiences
+a certain amount of errors in quick succession (fault persistence).
+Any task execution that experiences an error will abort execution
+(and therefore not produce any metrics) but the Bot **will not** shutdown until the fault persistence is tripped.
+
+All errors encountered during task exeuction are reported to the Cluster for later review by any users with appriopiate access.
+Tasks do not retry (by default), but updates to `bot.state` are maintained up until the point the error occured.
+
+It is important to keep track of these errors and ensure that none of them are in fact critical to the operation of your Bot,
+and to take corrective or preventative action if it is determined that it should be treated as a more critical failure condition.
+```
+
+```{note}
+Your Bots can also be monitored from the Platform UI at [https://silverback.apeworx.io](https://silverback.apeworx.io).
+```
+
+## Controlling your Bot
+
+As we already saw, once a Bot is configured in a Cluster,
+we can control it using commands from the [`silverback cluster bots`][silverback-cluster-bots] subcommand group.
+For example, we can attempt to start a Bot that is not currently running (after making configuration or code changes)
+using the [`silverback cluster bots start`][silverback-cluster-bots-start] command.
+We can also stop a bot using [`silverback cluster bots stop`][silverback-cluster-bots-stop]
+that is currently in the RUNNING state if we desire.
+
+```{note}
+Controlling your bots can be done from the Platform UI at
+[https://silverback.apeworx.io](https://silverback.apeworx.io),
+if you have the right permissions to do so.
+```
+
+<!-- TODO: Updating runtime parameters -->
+
+<!-- TODO: Downloading metrics from your Bot -->
+
 ## Model Context Server
 
-The Silverback package ships with an MCP ([Model Context Protocol](https://modelcontextprotocol.io/quickstart/user)) which you can use via the [`silverback cluster mcp`][silverback-cluster-mcp] command.
-This MCP server must be configured to run locally, and the easiest way to do so is to configure it in your LLM of choice.
+The Silverback package ships with an MCP ([Model Context Protocol](https://modelcontextprotocol.io))
+which you can use via the [`silverback cluster mcp`][silverback-cluster-mcp] command.
+This MCP server must be configured to run locally,
+and the easiest way to do so is to configure it in your LLM of choice.
 The config for using this with Claude Desktop is as follows:
 
 `~/.config/Claude/claude_desktop_config.json`:
@@ -68,14 +229,14 @@ The config for using this with Claude Desktop is as follows:
 ```json
 {
   "mcpServers": {
-    ...  # Other MCP servers go here
+    // Other MCP servers go here...
     "silverback": {
       "command": "<path to `uvx` or `uv` binary>",
       "args": [
         "silverback[mcp]",
         "cluster",
         "mcp"
-        # Add args `--cluster <cluster name>` to use a Cluster other than your profile default
+        // Add `--cluster <cluster name>` to use a Cluster other than your profile default
       ]
     }
   }
@@ -88,6 +249,17 @@ Once that has been configured, you can ask your LLM to do things like check the 
 The MCP will use the context from [`silverback login`][silverback-login] to execute, so be sure to log in before starting.
 ```
 
+[silverback-cluster-bots]: ../commands/cluster.html#silverback-cluster-bots
+[silverback-cluster-bots-errors]: ../commands/cluster.html#silverback-cluster-bots-errors
+[silverback-cluster-bots-health]: ../commands/cluster.html#silverback-cluster-bots-health
+[silverback-cluster-bots-info]: ../commands/cluster.html#silverback-cluster-bots-info
+[silverback-cluster-bots-list]: ../commands/cluster.html#silverback-cluster-bots-list
+[silverback-cluster-bots-logs]: ../commands/cluster.html#silverback-cluster-bots-logs
+[silverback-cluster-bots-new]: ../commands/cluster.html#silverback-cluster-bots-new
+[silverback-cluster-bots-remove]: ../commands/cluster.html#silverback-cluster-bots-remove
+[silverback-cluster-bots-start]: ../commands/cluster.html#silverback-cluster-bots-start
+[silverback-cluster-bots-stop]: ../commands/cluster.html#silverback-cluster-bots-stop
+[silverback-cluster-bots-update]: ../commands/cluster.html#silverback-cluster-bots-update
 [silverback-cluster-info]: ../commands/cluster.html#silverback-cluster-info
 [silverback-cluster-list]: ../commands/cluster.html#silverback-cluster-list
 [silverback-cluster-mcp]: ../commands/cluster.html#silverback-cluster-mcp
@@ -95,7 +267,13 @@ The MCP will use the context from [`silverback login`][silverback-login] to exec
 [silverback-cluster-pay-add-time]: ../commands/cluster.html#silverback-cluster-pay-add-time
 [silverback-cluster-pay-cancel]: ../commands/cluster.html#silverback-cluster-pay-cancel
 [silverback-cluster-pay-create]: ../commands/cluster.html#silverback-cluster-pay-create
+[silverback-cluster-registry-new]: ../commands/cluster.html#silverback-cluster-registry-new
 [silverback-cluster-update]: ../commands/cluster.html#silverback-cluster-update
+[silverback-cluster-vars]: ../commands/cluster.html#silverback-cluster-vars
+[silverback-cluster-vars-info]: ../commands/cluster.html#silverback-cluster-vars-info
+[silverback-cluster-vars-list]: ../commands/cluster.html#silverback-cluster-vars-list
+[silverback-cluster-vars-new]: ../commands/cluster.html#silverback-cluster-vars-new
+[silverback-cluster-vars-remove]: ../commands/cluster.html#silverback-cluster-vars-remove
 [silverback-cluster-workspaces]: ../commands/cluster.html#silverback-cluster-workspaces
 [silverback-cluster-workspaces-delete]: ../commands/cluster.html#silverback-cluster-workspaces-delete
 [silverback-cluster-workspaces-info]: ../commands/cluster.html#silverback-cluster-workspaces-info

--- a/docs/userguides/testing.md
+++ b/docs/userguides/testing.md
@@ -1,0 +1,3 @@
+# Testing Bots
+
+TODO: Add backtesting mode w/ `silverback test`


### PR DESCRIPTION
### What I did

Adds a number of clarifications to docs, including moving some of the userguide sections around (to more gradually introduce the Silverback Platform) and add reference material on designing for reorgs (see #259)

fixes: #259

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
