### PR TITLE
fix(Runner): display hidden task metrics with DEBUG

### DIFF
--- a/silverback/runner.py
+++ b/silverback/runner.py
@@ -108,7 +108,11 @@ class BaseRunner(ABC):
             f"{metric_name}: {datapoint.render()}"
             for metric_name, datapoint in result.metrics.items()
         ):  # Display metrics in logs to help debug
-            logger.info(f"{task_data.name} - Metrics collected\n  {metrics_str}")
+            # NOTE: Mimic behavior of displaying task start/completion in `middlewares.py`
+            if ":" in task_data.name:
+                logger.debug(f"{task_data.name} - Metrics collected\n  {metrics_str}")
+            else:
+                logger.info(f"{task_data.name} - Metrics collected\n  {metrics_str}")
 
             # Trigger checks for metric values
             for metric_name, datapoint in result.metrics.items():


### PR DESCRIPTION
### What I did

Noticed when defining an update to add bot integration to one of our SDKs that while "hidden tasks" (tasks that are namespaced via `:` character) log as DEBUG (instead of INFO for user-defined tasks), "hidden metrics" (metrics created by hidden tasks) was not.

### How I did it

Simple change, added a note reflected where it comes from

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
