### PR TITLE
fix(Build): examples were not building correctly

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,18 +125,42 @@ jobs:
           cache-from: type=gha,scope=build-py${{ matrix.python-version }}
           platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
-  example:
+  # NOTE: Test that above built image functions as a base image (no push)
+  examples-latest-sdk:
+    if: ${{ github.event_name == 'pull_request' }}
     # NOTE: We want the silverback image built above to base ours on
     needs: build
-    runs-on: ubuntu-latest
+    # NOTE: This speeds up testing by using an image with silverback pre-installed
+    runs-on: ghcr.io/apeworx/silverback:latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build Examples (using 'latest' SDK from above)
+        run: |
+          silverback build --generate \
+            --sdk latest \
+            --tag-base ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} \
+            --version pr-${{ github.event.pull_request.number }}
+
+  # Build actual image using stable as base
+  # NOTE: In PR, tests that build works with `stable` as well
+  examples-stable-sdk:
+    # NOTE: We want the silverback image built above to base ours on
+    needs: build
+    # NOTE: This speeds up testing by using an image with silverback pre-installed
+    runs-on: ghcr.io/apeworx/silverback:latest
     permissions:
       contents: read
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - name: Build Examples
+      # TODO: Refactor official action to use `stable` as base image for job
+      - name: Build Examples (Using official Github Action)
         uses: SilverbackLtd/build-action@v1
         with:
             push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -133,9 +133,6 @@ jobs:
     # NOTE: We want the silverback image built above to base ours on
     needs: build
     runs-on: ubuntu-latest
-    # NOTE: This speeds up testing by using an image with silverback pre-installed
-    container:
-      image: ghcr.io/apeworx/silverback:latest
     permissions:
       contents: read
       packages: read
@@ -143,11 +140,14 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Build Examples (using 'latest' SDK from above)
-        run: |
-          silverback build --generate \
-            --sdk latest \
-            --tag-base ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} \
-            --version pr-${{ github.event.pull_request.number }}
+        uses: SilverbackLtd/build-action@v1
+        with:
+          # TODO: add after 0.7.37 release (and update to build-action)
+          # sdk: latest
+          tag: pr-${{ github.event.pull_request.number }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
   # Build actual image using stable as base
   # NOTE: In PR, tests that build works with `stable` as well
@@ -155,10 +155,6 @@ jobs:
     # NOTE: We want the silverback image built above to base ours on
     needs: build
     runs-on: ubuntu-latest
-    # NOTE: This speeds up testing by using an image with silverback pre-installed
-    container:
-      # NOTE: Use `latest` **just for building** (will still use `stable` as base)
-      image: ghcr.io/apeworx/silverback:latest
     permissions:
       contents: read
       packages: write
@@ -166,15 +162,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # TODO: Refactor official action to use `stable` as base image for job
       - name: Build Examples (Using official Github Action)
         uses: SilverbackLtd/build-action@v1
         with:
-            push: ${{ github.event_name != 'pull_request' }}
-            tag: latest
-            registry: ghcr.io
-            username: ${{ github.actor }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tag: latest
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
   prune-registry:
     needs: build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -165,7 +165,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Build Examples (Using official Github Action)
-        uses: SilverbackLtd/build-action@v1
+        # uses: SilverbackLtd/build-action@v1
+        uses: SilverbackLtd/build-action@main
         with:
           push: ${{ github.event_name != 'pull_request' }}
           tag: latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,6 +120,8 @@ jobs:
             PYTHON_VERSION=${{ matrix.python-version }}
             VERSION=${{ steps.version.outputs.version }}
           push: ${{ github.event_name != 'pull_request' }}
+          # NOTE: So examples can build in next job
+          load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=build-py${{ matrix.python-version }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -172,6 +172,7 @@ jobs:
             password: ${{ secrets.GITHUB_TOKEN }}
 
   prune-registry:
+    needs: build
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -139,15 +139,17 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Setup Python tool
+        uses: astral-sh/setup-uv@v7
+
+      # NOTE: Temporary until build action supports `--sdk`
       - name: Build Examples (using 'latest' SDK from above)
-        uses: SilverbackLtd/build-action@v1
-        with:
-          # TODO: add after 0.7.37 release (and update to build-action)
-          # sdk: latest
-          tag: pr-${{ github.event.pull_request.number }}
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          uv run silverback build \
+            --generate \
+            --sdk latest \
+            --tag-base $(echo '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]') \
+            --version pr-${{ github.event.pull_request.number }}
 
   # Build actual image using stable as base
   # NOTE: In PR, tests that build works with `stable` as well

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,20 +125,6 @@ jobs:
           cache-from: type=gha,scope=build-py${{ matrix.python-version }}
           platforms: ${{ github.event_name != 'pull_request' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
 
-      - name: Run container retention policy
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: snok/container-retention-policy@v3.0.1
-        with:
-          account: ApeWorX
-          token: ${{ secrets.GITHUB_TOKEN }}
-          image-names: "silverback"
-          # NOTE: Keep stable/stable-slim, latest/latest-slim, all 0.8.x series, and last in 0.7.x series
-          # TODO: Add `!*v0.8*` when released, move `!*v0.7*` to last patch version
-          image-tags: "!*stable* !*latest* !*v0.7*"
-          tag-selection: both
-          cut-off: 4w
-          dry-run: true
-
   example:
     # NOTE: We want the silverback image built above to base ours on
     needs: build
@@ -158,3 +144,25 @@ jobs:
             registry: ghcr.io
             username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
+
+  prune-registry:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Run container retention policy
+        uses: snok/container-retention-policy@v3.0.1
+        with:
+          account: ApeWorX
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: "silverback"
+          # NOTE: Keep stable/stable-slim, latest/latest-slim, all 0.8.x series, and last in 0.7.x series
+          # TODO: Add `!*v0.8*` when released, move `!*v0.7*` to last patch version
+          image-tags: "!*stable* !*latest* !*v0.7*"
+          tag-selection: both
+          cut-off: 4w
+          dry-run: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,8 +132,10 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     # NOTE: We want the silverback image built above to base ours on
     needs: build
+    runs-on: ubuntu-latest
     # NOTE: This speeds up testing by using an image with silverback pre-installed
-    runs-on: ghcr.io/apeworx/silverback:latest
+    container:
+      image: ghcr.io/apeworx/silverback:latest
     permissions:
       contents: read
       packages: read
@@ -152,8 +154,11 @@ jobs:
   examples-stable-sdk:
     # NOTE: We want the silverback image built above to base ours on
     needs: build
+    runs-on: ubuntu-latest
     # NOTE: This speeds up testing by using an image with silverback pre-installed
-    runs-on: ghcr.io/apeworx/silverback:latest
+    container:
+      # NOTE: Use `latest` **just for building** (will still use `stable` as base)
+      image: ghcr.io/apeworx/silverback:latest
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_APE_IMAGE="ghcr.io/apeworx/ape:python${PYTHON_VERSION}-stable-slim"
 
 # Stage 1: Build dependencies
 # NOTE: Build with builder image to reduce image size
-FROM ${BASE_APE_IMAGE} as slim-builder
+FROM ${BASE_APE_IMAGE} AS slim-builder
 
 # NOTE: Switch back to root for building
 USER root

--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -33,13 +33,13 @@ def containerfile_template(
         )
 
     if requirements_txt_fname:
-        steps.append(f"COPY {requirements_txt_fname} requirements.txt")
+        steps.append(f"COPY --chown=harambe:harambe {requirements_txt_fname} requirements.txt")
 
     if has_pyproject_toml:
-        steps.append("COPY pyproject.toml .")
+        steps.append("COPY --chown=harambe:harambe pyproject.toml .")
 
     if has_ape_config_yaml:
-        steps.append("COPY ape-config.yaml .")
+        steps.append("COPY --chown=harambe:harambe ape-config.yaml .")
 
     if requirements_txt_fname or has_pyproject_toml:
         steps.append("COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/")
@@ -52,11 +52,11 @@ def containerfile_template(
         steps.append("RUN ape plugins install -U .")
 
     if contracts_folder:
-        steps.append(f"COPY {contracts_folder} {contracts_folder}")
+        steps.append(f"COPY --chown=harambe:harambe {contracts_folder} {contracts_folder}")
         steps.append("RUN ape compile")
 
     bot_dest = "bot/" if bot_path.is_dir() else "bot.py"
-    steps.append(f"COPY {bot_path} {bot_dest}")
+    steps.append(f"COPY --chown=harambe:harambe {bot_path} {bot_dest}")
 
     return "\n".join(steps)
 

--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -42,7 +42,7 @@ def containerfile_template(
         steps.append("COPY ape-config.yaml .")
 
     if requirements_txt_fname or has_pyproject_toml:
-        steps.append("RUN pip install --upgrade pip")
+        steps.append("COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/")
 
         # NOTE: Only install project via `pyproject.toml` if `requirements-bot.txt` DNE
         install_arg = "-r requirements.txt" if requirements_txt_fname else "."

--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -18,11 +18,19 @@ def containerfile_template(
 ):
     steps = [
         f"FROM ghcr.io/apeworx/silverback:{sdk_version}",
-        "USER root",
-        "WORKDIR /app",
-        "RUN chown harambe:harambe /app",
-        "USER harambe",
     ]
+
+    if sdk_version == "v0.7.36":
+        # NOTE: Some versions of the base image (using Ape v0.8.{46,47}) do not ensure this
+        #       see: https://github.com/ApeWorX/ape/pull/2753
+        # TODO: Remove in Silverback v0.8.x (no longer maintaining v0.7.36)
+        steps.extend(
+            [
+                "USER root",
+                "RUN chown harambe:harambe .",
+                "USER harambe",
+            ]
+        )
 
     if requirements_txt_fname:
         steps.append(f"COPY {requirements_txt_fname} requirements.txt")

--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -102,9 +102,7 @@ def generate_containerfiles(path: Path, sdk_version: str = "stable"):
                     has_pyproject_toml=has_pyproject_toml,
                     has_ape_config_yaml=has_ape_config_yaml,
                     contracts_folder=(
-                        contracts_folder
-                        if (Path.cwd() / contracts_folder).exists()
-                        else None
+                        contracts_folder if (Path.cwd() / contracts_folder).exists() else None
                     ),
                 )
             )
@@ -118,9 +116,7 @@ def generate_containerfiles(path: Path, sdk_version: str = "stable"):
                 has_pyproject_toml=has_pyproject_toml,
                 has_ape_config_yaml=has_ape_config_yaml,
                 contracts_folder=(
-                    contracts_folder
-                    if (Path.cwd() / contracts_folder).exists()
-                    else None
+                    contracts_folder if (Path.cwd() / contracts_folder).exists() else None
                 ),
             )
         )

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -186,13 +186,20 @@ def run(cli_ctx, account, runner_class, record, recorder_class, max_exceptions, 
     help="Version label to use for tagging final bot images. Defaults to 'latest'.",
 )
 @click.option(
+    "--sdk",
+    "sdk_version",
+    default="stable",
+    metavar="VERSION",
+    help="Version of Silverback SDK to use as base image. Defaults to 'stable'.",
+)
+@click.option(
     "--push",
     is_flag=True,
     default=False,
     help="Push image to logged-in registry. Defaults to false.",
 )
 @click.argument("path", required=False, default=None)
-def build(use_docker, generate, tag_base, version, push, path):
+def build(use_docker, generate, tag_base, version, sdk_version, push, path):
     """
     Generate Dockerfiles and build bot container images
 
@@ -227,7 +234,7 @@ def build(use_docker, generate, tag_base, version, push, path):
                 ", or process all '*.py' bots in  'bots/' folder."
             )
 
-        generate_containerfiles(path)
+        generate_containerfiles(path, sdk_version=sdk_version)
 
     if not (Path.cwd() / IMAGES_FOLDER_NAME).exists():
         raise click.ClickException(

--- a/silverback/_cli.py
+++ b/silverback/_cli.py
@@ -173,8 +173,9 @@ def run(cli_ctx, account, runner_class, record, recorder_class, max_exceptions, 
     "--tag-base",
     default=None,
     help=(
-        "The base to use to tag the image. "
-        "The bot name (or 'bot') is appended to it, following a '-' separator. "
+        "The base to use to tag the final bot image(s). "
+        "If multiple bots are in the project, the name of the bot is appended to it, following a '-' separator. "
+        "If only one bot, then `-bot` is used. "
         "Defaults to using the name of the folder you are building from."
     ),
 )
@@ -182,7 +183,7 @@ def run(cli_ctx, account, runner_class, record, recorder_class, max_exceptions, 
     "--version",
     default="latest",
     metavar="VERSION",
-    help="Version to use in tag. Defaults to 'latest'.",
+    help="Version label to use for tagging final bot images. Defaults to 'latest'.",
 )
 @click.option(
     "--push",


### PR DESCRIPTION
### What I did

Noticed in CI that the example bots were not building

This PR also adds a flag to `silverback build` to select which SDK version to use as the base image.
Additionally, it makes some other minor refactors to reduce unnecessarily complex code, and adds a test for checking that the `latest` SDK (in PR, the build image from the previous job) can build images for itself.

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
