### PR TITLE
fix: handle pinned Ape plugins in build generation

### DIFF
--- a/docs/userguides/deploying.md
+++ b/docs/userguides/deploying.md
@@ -50,6 +50,12 @@ It will then automatically build them for you (monitor the output for any issues
 Assuming the build commands succeed, you will have fully-built images that you can push into a Registry.
 
 ```{note}
+If your project pins Ape plugin versions in `ape-config.yaml` or `pyproject.toml`,
+the generated Dockerfiles automatically avoid `ape plugins install -U .` and instead
+use `ape plugins install .` so version-pinned plugin builds continue to work.
+```
+
+```{note}
 If you chose the `bot/` project structure and `bot` is a Python package, you will be unable to use the dockerfile generation feature.
 This method will warn you that you are generating bots for a python package, but will not stop you from attempting to do so.
 When you generate the dockerfiles, be aware that it will only copy the `bot/` folder into the Dockerfile,

--- a/silverback/_build_utils.py
+++ b/silverback/_build_utils.py
@@ -8,12 +8,40 @@ import yaml
 IMAGES_FOLDER_NAME = ".silverback-images"
 
 
+def _has_pinned_plugin_versions(plugins) -> bool:
+    if not plugins:
+        return False
+
+    return any(hasattr(plugin, "get") and plugin.get("version") is not None for plugin in plugins)
+
+
+def _project_uses_pinned_ape_plugins(
+    ape_config_path: Path | None = None, pyproject_path: Path | None = None
+) -> bool:
+    ape_config_path = ape_config_path or (Path.cwd() / "ape-config.yaml")
+    pyproject_path = pyproject_path or (Path.cwd() / "pyproject.toml")
+
+    if ape_config_path.exists():
+        ape_config = yaml.safe_load(ape_config_path.read_text()) or {}
+        if _has_pinned_plugin_versions(ape_config.get("plugins")):
+            return True
+
+    if pyproject_path.exists():
+        pyproject = tomlkit.loads(pyproject_path.read_text())
+        ape_config = pyproject.get("tool", {}).get("ape", {})
+        if _has_pinned_plugin_versions(ape_config.get("plugins")):
+            return True
+
+    return False
+
+
 def containerfile_template(
     bot_path: Path,
     sdk_version: str = "stable",
     requirements_txt_fname: str | None = None,
     has_pyproject_toml: bool = False,
     has_ape_config_yaml: bool = False,
+    upgrade_ape_plugins: bool = True,
     contracts_folder: str | None = None,
 ):
     steps = [
@@ -49,7 +77,11 @@ def containerfile_template(
         steps.append(f"RUN uv pip install {install_arg}")
 
     if has_pyproject_toml or has_ape_config_yaml:
-        steps.append("RUN ape plugins install -U .")
+        ape_plugins_install_cmd = "RUN ape plugins install"
+        if upgrade_ape_plugins:
+            ape_plugins_install_cmd = f"{ape_plugins_install_cmd} -U"
+
+        steps.append(f"{ape_plugins_install_cmd} .")
 
     if contracts_folder:
         steps.append(f"COPY --chown=harambe:harambe {contracts_folder} {contracts_folder}")
@@ -63,6 +95,7 @@ def containerfile_template(
 
 def generate_containerfiles(path: Path, sdk_version: str = "stable"):
     (Path.cwd() / IMAGES_FOLDER_NAME).mkdir(exist_ok=True)
+    uses_pinned_ape_plugins = _project_uses_pinned_ape_plugins()
 
     contracts_folder: str = "contracts"
     if has_ape_config_yaml := (ape_config_path := Path.cwd() / "ape-config.yaml").exists():
@@ -100,6 +133,7 @@ def generate_containerfiles(path: Path, sdk_version: str = "stable"):
                     requirements_txt_fname=requirements_txt_fname,
                     has_pyproject_toml=has_pyproject_toml,
                     has_ape_config_yaml=has_ape_config_yaml,
+                    upgrade_ape_plugins=not uses_pinned_ape_plugins,
                     contracts_folder=(
                         contracts_folder if (Path.cwd() / contracts_folder).exists() else None
                     ),
@@ -114,6 +148,7 @@ def generate_containerfiles(path: Path, sdk_version: str = "stable"):
                 requirements_txt_fname=requirements_txt_fname,
                 has_pyproject_toml=has_pyproject_toml,
                 has_ape_config_yaml=has_ape_config_yaml,
+                upgrade_ape_plugins=not uses_pinned_ape_plugins,
                 contracts_folder=(
                     contracts_folder if (Path.cwd() / contracts_folder).exists() else None
                 ),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 import pytest
 
-from silverback._build_utils import containerfile_template
+from silverback._build_utils import (
+    IMAGES_FOLDER_NAME,
+    containerfile_template,
+    generate_containerfiles,
+)
 from silverback.utils import decode_topics_from_string, encode_topics_to_string
 
 
@@ -66,3 +70,58 @@ def test_containerfile_generation(bot_path, build_args):
         assert "ape-config.yaml" in containerfile
     if contracts_folder := build_args.get("contracts_folder"):
         assert contracts_folder in containerfile
+
+
+@pytest.mark.parametrize(
+    ("config_name", "config_contents"),
+    [
+        (
+            "ape-config.yaml",
+            'plugins:\n  - name: "aws"\n    version: ">=0.8.1b1"\n',
+        ),
+        (
+            "pyproject.toml",
+            '[[tool.ape.plugins]]\nname = "aws"\nversion = ">=0.8.1b1"\n',
+        ),
+    ],
+)
+def test_generate_containerfiles_avoids_upgrade_for_pinned_plugins(
+    tmp_path, monkeypatch, config_name, config_contents
+):
+    bot_path = tmp_path / "bot.py"
+    bot_path.write_text("from silverback import SilverbackBot\n")
+    (tmp_path / config_name).write_text(config_contents)
+
+    monkeypatch.chdir(tmp_path)
+    generate_containerfiles(bot_path)
+
+    containerfile = (tmp_path / IMAGES_FOLDER_NAME / "Dockerfile.bot").read_text()
+    assert "RUN ape plugins install ." in containerfile
+    assert "RUN ape plugins install -U ." not in containerfile
+
+
+@pytest.mark.parametrize(
+    ("config_name", "config_contents"),
+    [
+        (
+            "ape-config.yaml",
+            'plugins:\n  - name: "aws"\n',
+        ),
+        (
+            "pyproject.toml",
+            '[[tool.ape.plugins]]\nname = "aws"\n',
+        ),
+    ],
+)
+def test_generate_containerfiles_keeps_upgrade_for_unpinned_plugins(
+    tmp_path, monkeypatch, config_name, config_contents
+):
+    bot_path = tmp_path / "bot.py"
+    bot_path.write_text("from silverback import SilverbackBot\n")
+    (tmp_path / config_name).write_text(config_contents)
+
+    monkeypatch.chdir(tmp_path)
+    generate_containerfiles(bot_path)
+
+    containerfile = (tmp_path / IMAGES_FOLDER_NAME / "Dockerfile.bot").read_text()
+    assert "RUN ape plugins install -U ." in containerfile


### PR DESCRIPTION
### What I did

Updated generated Dockerfiles so Silverback does not call `ape plugins install -U .` when project Ape plugins are version-pinned.

fixes: #220

### How I did it

- inspected Ape project config for pinned plugin versions in `ape-config.yaml` and `pyproject.toml`
- generated `ape plugins install .` for pinned-plugin projects
- preserved `ape plugins install -U .` for unpinned projects
- added regression tests for both supported config formats
- documented the pinned-plugin behavior in the deployment guide

### How to verify it

```bash
. .venv/bin/activate && pytest tests/test_utils.py -q
. .venv/bin/activate && ruff check silverback/_build_utils.py tests/test_utils.py
. .venv/bin/activate && ruff format --check silverback/_build_utils.py tests/test_utils.py
```

Then review `docs/userguides/deploying.md` for the pinned-plugin deployment note.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
